### PR TITLE
Fetch registry at startup

### DIFF
--- a/src/redux/config.ts
+++ b/src/redux/config.ts
@@ -1,4 +1,4 @@
-let network: any, provider: any;
+let network: any, defaultProvider: any;
 
 if (process.env.NODE_ENV === 'production') {
   network = {
@@ -6,7 +6,7 @@ if (process.env.NODE_ENV === 'production') {
     explorer: 'https://blockstream.info/liquid/api',
   };
 
-  provider = {
+  defaultProvider = {
     endpoint: 'https://provider.tdex.network:9945',
   };
 } else {
@@ -15,9 +15,9 @@ if (process.env.NODE_ENV === 'production') {
     explorer: 'http://localhost:3001',
   };
 
-  provider = {
+  defaultProvider = {
     endpoint: 'http://localhost:9945',
   };
 }
 
-export { network, provider };
+export { network, defaultProvider };

--- a/src/redux/services/walletService.ts
+++ b/src/redux/services/walletService.ts
@@ -1,9 +1,11 @@
 import { Storage } from '@capacitor/core';
-import { provider } from '../config';
+import { defaultProvider } from '../config';
 import { Mnemonic } from 'ldk';
 import axios from 'axios';
 
-export const axiosProviderObject = axios.create({ baseURL: provider.endpoint });
+export const axiosProviderObject = axios.create({
+  baseURL: defaultProvider.endpoint,
+});
 
 export const getAssetsRequest = (
   path: string,


### PR DESCRIPTION
This PR rethink the way we restore providers. Each time the user sign in, the following steps are executed:
1. add the providers persisted in local storage.
2. fetch the providers from registry --> add them to state (**only if we have not already added it**)
3. if any error occurs -> add the default provider (specified in config)

it closes #174 
it closes #87 

please review @tiero 