### PR TITLE
Use a single modal in restore to avoid flickering + Pin refactor

### DIFF
--- a/src/components/PinInput/index.tsx
+++ b/src/components/PinInput/index.tsx
@@ -3,12 +3,17 @@ import classNames from 'classnames';
 import { IonInput, IonGrid, IonRow, IonCol } from '@ionic/react';
 import { onPressEnterKeyFactory } from '../../utils/keyboard';
 import './style.scss';
+import {
+  PIN_TIMEOUT_FAILURE,
+  PIN_TIMEOUT_SUCCESS,
+} from '../../utils/constants';
 
 interface PinInputProps {
   onPin: (newPin: string) => void;
   on6digits: () => void;
   isWrongPin: boolean | null;
   inputRef: React.RefObject<HTMLIonInputElement>;
+  pin: string;
 }
 
 const PinInput: React.FC<PinInputProps> = ({
@@ -16,9 +21,8 @@ const PinInput: React.FC<PinInputProps> = ({
   on6digits,
   isWrongPin,
   inputRef,
+  pin,
 }) => {
-  const [pin, setPin] = useState('');
-
   useEffect(() => {
     setTimeout(() => {
       if (inputRef && inputRef.current) {
@@ -29,24 +33,27 @@ const PinInput: React.FC<PinInputProps> = ({
 
   const onNewPin = (newPin: string | null | undefined) => {
     if (!newPin) {
-      setPin('');
+      onPin('');
       return;
     }
     if (newPin.length > 6) {
-      setPin(newPin.slice(6));
+      onPin(newPin.slice(6));
       return;
     }
-    setPin(newPin);
+    onPin(newPin);
     if (newPin.length === 6) {
       onPin(newPin);
-      if (isWrongPin === true || isWrongPin === null) {
-        setTimeout(() => setPin(''), 2000);
+      if (isWrongPin === true) {
+        setTimeout(() => onPin(''), PIN_TIMEOUT_FAILURE);
+      }
+      if (isWrongPin === null) {
+        setTimeout(() => onPin(''), PIN_TIMEOUT_SUCCESS);
       }
     }
   };
 
   return (
-    <IonGrid>
+    <IonGrid id="pin-input-container">
       <IonRow>
         <IonCol offset="1" size="10">
           <IonGrid className="pin-wrapper">

--- a/src/components/PinModal/index.tsx
+++ b/src/components/PinModal/index.tsx
@@ -25,6 +25,8 @@ interface PinModalProps {
   onClose?: () => void;
   onDidDismiss?: boolean;
   isWrongPin: boolean | null;
+  needReset?: boolean;
+  setNeedReset?: (b: boolean) => void;
 }
 
 const PinModal: React.FC<PinModalProps> = ({
@@ -35,11 +37,20 @@ const PinModal: React.FC<PinModalProps> = ({
   onConfirm,
   onDidDismiss,
   isWrongPin,
+  needReset,
+  setNeedReset,
 }) => {
   const validRegexp = new RegExp('\\d{6}');
   const [pin, setPin] = useState('');
   const dispatch = useDispatch();
   const inputRef = useRef<any>(null);
+
+  useEffect(() => {
+    if (needReset) {
+      setPin('');
+      setNeedReset?.(false);
+    }
+  }, [needReset]);
 
   const handleConfirm = () => {
     if (validRegexp.test(pin)) {
@@ -70,7 +81,7 @@ const PinModal: React.FC<PinModalProps> = ({
   return (
     <IonModal
       animated={false}
-      cssClass="modal-big withdrawal"
+      cssClass="modal-big"
       isOpen={open}
       keyboardClose={false}
       onDidDismiss={onDidDismiss ? onClose : undefined}
@@ -93,8 +104,9 @@ const PinModal: React.FC<PinModalProps> = ({
         <PinInput
           inputRef={inputRef}
           on6digits={handleConfirm}
-          onPin={(p: string) => setPin(p)}
+          onPin={setPin}
           isWrongPin={isWrongPin}
+          pin={pin}
         />
       </IonContent>
     </IonModal>

--- a/src/components/PinModal/style.scss
+++ b/src/components/PinModal/style.scss
@@ -1,3 +1,5 @@
-.error-msg {
-  text-align: center;
+#pin-input-container {
+  position: absolute;
+  top: 140px;
+  width: 100%;
 }


### PR DESCRIPTION
Use a single PIN modal in Restore to avoid flickering between the two modals. 
Refactor modal state, pass PIN state to PinInput. 
Allow PIN state reset.