### PR TITLE
Remove spinner on Receive page

### DIFF
--- a/src/pages/Receive/index.tsx
+++ b/src/pages/Receive/index.tsx
@@ -3,7 +3,6 @@ import {
   IonContent,
   IonItem,
   IonIcon,
-  IonSpinner,
   IonLoading,
   IonGrid,
 } from '@ionic/react';


### PR DESCRIPTION
It closes #213 
After consideration, Just removing the spinner seems enough. We have a loader when page loads, then loader stops and screen shows the address and QR code.