### PR TITLE
Fix coin loss when swapping

### DIFF
--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -156,7 +156,7 @@ const Exchange: React.FC<ExchangeProps> = ({
   }, [assetSent, assetReceived, markets]);
 
   useEffect(() => {
-    if (!assetSent) return;
+    if (!assetSent || assetReceived) return;
     const tradable = getTradablesAssets(markets, assetSent.asset);
     setTradableAssets(tradable);
     setAssetReceived(tradable[0]);


### PR DESCRIPTION
It closes #226 

When swapping `assetReceived` should already be set. Check if `assetReceived` exists to prevent entering useEffect when swapping.

Please review @tiero