### PR TITLE
Fix price conversion bug

### DIFF
--- a/src/components/ExchangeRow/index.tsx
+++ b/src/components/ExchangeRow/index.tsx
@@ -5,7 +5,9 @@ import { BalanceInterface } from '../../redux/actionTypes/walletActionTypes';
 import {
   fromSatoshi,
   fromSatoshiFixed,
+  isLbtc,
   toLBTCwithUnit,
+  toSatoshi,
 } from '../../utils/helpers';
 import {
   IonIcon,
@@ -36,7 +38,7 @@ import { useSelector } from 'react-redux';
 const ERROR_BALANCE_TOO_LOW = 'Amount is greater than your balance';
 
 interface ExchangeRowInterface {
-  checkBalance?: boolean;
+  checkBalance: boolean;
   // the asset handled by the component.
   asset: AssetWithTicker;
   // using to auto-update with best trade price
@@ -46,6 +48,7 @@ interface ExchangeRowInterface {
   // actions to parent component.
   onChangeAmount: (newAmount: number) => void;
   setTrade: (trade: TDEXTrade) => void;
+  trade?: TDEXTrade;
   // for exchange search
   assetsWithTicker: AssetWithTicker[];
   setAsset: (newAsset: AssetWithTicker) => void;
@@ -63,6 +66,7 @@ interface ExchangeRowInterface {
 
 const ExchangeRow: React.FC<ExchangeRowInterface> = ({
   trades,
+  trade,
   relatedAssetHash,
   relatedAssetAmount,
   asset,
@@ -100,8 +104,9 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
 
   useEffect(() => {
     void (async (): Promise<void> => {
-      let trade;
+      let newTrade;
       let bestPriceRes;
+      let updatedAmount;
       if (focused || trades.length === 0 || !relatedAssetHash) return; // skip the effect if the input field is focused
       if (relatedAssetAmount === 0) {
         onChangeAmount(0);
@@ -109,7 +114,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
       }
       setIsUpdating(true);
       try {
-        trade = await bestBalance(trades);
+        newTrade = await bestBalance(trades);
       } catch (err) {
         console.error(err);
         setError(err.message);
@@ -122,29 +127,51 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
           trades,
           console.error
         );
-        trade = bestPriceRes.trade;
+        newTrade = bestPriceRes.trade;
       }
-      setTrade(trade);
-      const price = await calculatePrice(
+      const priceInSats = await calculatePrice(
         {
           amount: relatedAssetAmount,
           asset: relatedAssetHash,
           precision: assets[relatedAssetHash]?.precision || defaultPrecision,
         },
-        trade
+        newTrade
       );
-      const precision = assets[price.asset]?.precision || defaultPrecision;
-      const updatedAmount = fromSatoshiFixed(
-        price.amount,
-        precision,
-        precision,
-        balance?.ticker === 'L-BTC' ? lbtcUnit : undefined
-      );
+      setTrade(newTrade);
+      //
+      if (isLbtc(asset.asset)) {
+        const precision =
+          assets[priceInSats.asset]?.precision || defaultPrecision;
+        updatedAmount = fromSatoshiFixed(
+          priceInSats.amount,
+          precision,
+          precision,
+          isLbtc(asset.asset) ? lbtcUnit : undefined
+        );
+      } else {
+        // Convert fiat
+        const priceInBtc = fromSatoshi(
+          priceInSats.amount,
+          assets[priceInSats.asset]?.precision || defaultPrecision,
+          'L-BTC'
+        );
+        updatedAmount = toLBTCwithUnit(priceInBtc, lbtcUnit).toLocaleString(
+          'en-US',
+          {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: assets[relatedAssetHash]?.precision,
+            useGrouping: false,
+          }
+        );
+      }
       setAmount(updatedAmount);
-      onChangeAmount(fromSatoshi(price.amount, precision));
+      onChangeAmount(parseFloat(updatedAmount));
       setIsUpdating(false);
     })();
-  }, [relatedAssetAmount, relatedAssetHash, asset]);
+    // Need 'trade' to compute price based on last trade with proper type
+    // Need 'asset' which is accurate faster than balance
+    // Need 'balance' to display quote asset price
+  }, [relatedAssetAmount, relatedAssetHash, asset, balance, trade]);
 
   return (
     <div className="exchange-coin-container">
@@ -176,6 +203,9 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
               debounce={200}
               onIonChange={(e) => {
                 if (!isUpdating) {
+                  if (e.detail.value && e.detail.value.length >= 12) {
+                    return;
+                  }
                   if (!e.detail.value) {
                     setError('');
                     setAmount('');
@@ -183,18 +213,19 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
                     return;
                   }
                   const val = e.detail.value.replace(',', '.');
-                  const inputAmount = toLBTCwithUnit(
+                  const valSats = toSatoshi(
                     parseFloat(val),
-                    balance?.ticker === 'L-BTC' ? lbtcUnit : undefined
+                    balance?.precision,
+                    isLbtc(asset.asset) ? lbtcUnit : undefined
                   );
                   setAmount(val);
-                  onChangeAmount(inputAmount);
-                  const sats = fromSatoshi(
+                  onChangeAmount(parseFloat(val));
+                  const balanceSats = toSatoshi(
                     balance?.amount || 0,
-                    balance?.precision
+                    balance?.precision,
+                    isLbtc(asset.asset) ? lbtcUnit : undefined
                   );
-
-                  if (checkBalance && inputAmount > sats) {
+                  if (checkBalance && valSats > balanceSats) {
                     setError(ERROR_BALANCE_TOO_LOW);
                   }
                 }

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -90,7 +90,7 @@ const Exchange: React.FC<ExchangeProps> = ({
   // errors
   const [errorSent, setErrorSent] = useState('');
   const [errorReceived, setErrorReceived] = useState('');
-
+  //
   const [modalOpen, setModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [isWrongPin, setIsWrongPin] = useState<boolean | null>(null);
@@ -261,7 +261,7 @@ const Exchange: React.FC<ExchangeProps> = ({
               isTitleLarge={true}
             />
             <ExchangeRow
-              checkBalance
+              checkBalance={true}
               focused={isFocused === 'sent'}
               setFocus={() => setIsFocused('sent')}
               setTrade={(t: TDEXTrade) => setTrade(t)}
@@ -269,6 +269,7 @@ const Exchange: React.FC<ExchangeProps> = ({
               relatedAssetHash={assetReceived?.asset || ''}
               asset={assetSent}
               trades={trades}
+              trade={trade}
               onChangeAmount={(newAmount: number) => {
                 setSentAmount(newAmount);
                 checkAvailableAmountSent();
@@ -286,9 +287,8 @@ const Exchange: React.FC<ExchangeProps> = ({
             <div
               className="exchange-divider"
               onClick={() => {
-                const firstAsset = { ...assetSent };
                 setAssetSent(assetReceived);
-                setAssetReceived(firstAsset);
+                setAssetReceived(assetSent);
               }}
             >
               <img src={swap} alt="swap" />
@@ -296,10 +296,12 @@ const Exchange: React.FC<ExchangeProps> = ({
 
             {assetReceived && (
               <ExchangeRow
+                checkBalance={false}
                 focused={isFocused === 'receive'}
                 setFocus={() => setIsFocused('receive')}
                 setTrade={(t: TDEXTrade) => setTrade(t)}
                 trades={trades}
+                trade={trade}
                 relatedAssetAmount={sentAmount || 0}
                 relatedAssetHash={assetSent?.asset || ''}
                 asset={assetReceived}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -71,7 +71,7 @@ export function toLBTCwithUnit(lbtcValue: number, unit?: string): number {
     case 'L-bits':
       return lbtcValue / 1000000;
     case 'L-sats':
-      return fromSatoshi(lbtcValue, 8);
+      return lbtcValue / 100000000;
     default:
       return lbtcValue;
   }
@@ -225,6 +225,10 @@ function getAssetHashLBTC() {
   if (network.chain === 'regtest')
     return '5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225';
   return '6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d';
+}
+
+export function isLbtc(asset: string) {
+  return asset === getAssetHashLBTC();
 }
 
 /**


### PR DESCRIPTION
It fixes #230 

Other issues remain that will be addressed in other PRs.
  - When editing bottom half value, top half gets incorrect value
  - Decimal separator is a comma instead of a dot

You may experience flickering where price is updated quickly. This is because sometimes it first compute the price with the wrong trade type, and at the end computed with the right one. If no proper solution is found maybe we can display a Skeleton for a few milliseconds waiting to have the final price.

   