### PR TITLE
Clean input amount and error

### DIFF
--- a/src/components/ExchangeRow/index.tsx
+++ b/src/components/ExchangeRow/index.tsx
@@ -88,10 +88,13 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
 
   useIonViewDidEnter(() => {
     setAccessoryBar(true).catch(console.error);
+    setError('');
+    setAmount('');
   });
 
   useIonViewDidLeave(() => {
     setAccessoryBar(false).catch(console.error);
+    setAmount('');
   });
 
   useEffect(() => {


### PR DESCRIPTION
Clean Exchange input amounts and errors to always have zero greyed amounts without errors when entering screen.
Both useIonViewDidEnter and useIonViewDidLeave are necessary.

Please review @tiero 