### PR TITLE
Remove safe area margin

### DIFF
--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -19,13 +19,6 @@
     --ion-font-size-main: 0.9rem;
     --ion-font-size-sub: 0.7rem;
   }
-  /** Safe Area **/
-  .ios {
-    --ion-safe-area-top: 40px;
-  }
-  .md {
-    --ion-safe-area-top: 60px;
-  }
 }
 
 /* DARK MODE */


### PR DESCRIPTION
The "layout strategy" has changed in recent commits and the safe area top margin is not necessary anymore. 
I tested on several emulated and real iOS/Android phones. The top margin is enough without safe area.