### PR TITLE
Exchange input display sanitising + Numeric keyboard

### DIFF
--- a/src/components/ExchangeRow/index.tsx
+++ b/src/components/ExchangeRow/index.tsx
@@ -193,12 +193,6 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
         // Hack to trigger a re-render
         setAmount('');
       }
-      if (!e.detail.value) {
-        setError('');
-        setAmount('');
-        onChangeAmount(0);
-        return;
-      }
       const val = e.detail.value
         .replace(',', '.')
         // Remove non numeric chars or period


### PR DESCRIPTION
When focusing on Exchange inputs, keyboard is numerical only + "." in Android / "," in iOS. Using input type "tel".
If comma is entered it will be replaced by a dot.
If by any chance the user is able to enter letters, they will be stripped out.
The computed counter-value has a dot as decimal separator.

It closes #254 

Please review @tiero 