### PR TITLE
Don't return blockTime as a component

### DIFF
--- a/src/pages/TradeSummary/index.tsx
+++ b/src/pages/TradeSummary/index.tsx
@@ -194,7 +194,9 @@ const TradeSummary: React.FC<TradeSummaryProps> = ({ history, location }) => {
                         </div>
                         <div className="transaction-info-values">
                           <span className="transaction-col-name">{''}</span>
-                          {transaction?.blockTime || (
+                          {transaction?.blockTime ? (
+                            <></>
+                          ) : (
                             <span className="transaction-col-value pending">
                               <IonText color="warning">PENDING</IonText>
                               <IonIcon


### PR DESCRIPTION
blockTime should not be returned as it was a valid component. 
Was causing crash on refresh after a tx was made.

Please review @tiero 