### PR TITLE
Refactor Sign-In / Wallet Restoration flow

### DIFF
--- a/src/components/CircleTotalBalance/index.tsx
+++ b/src/components/CircleTotalBalance/index.tsx
@@ -5,7 +5,7 @@ import TdexLogo from '../../assets/img/tdex_logo_black.svg';
 import './style.scss';
 
 interface CircleTotalBalanceProps {
-  fiatBalance: string | undefined;
+  fiatBalance: string;
   lbtcUnit: string;
   totalBalance: string;
 }

--- a/src/components/Refresher/index.tsx
+++ b/src/components/Refresher/index.tsx
@@ -3,7 +3,7 @@ import { chevronDownCircleOutline } from 'ionicons/icons';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
-import { update } from '../../redux/actions/appActions';
+import { updateState } from '../../redux/actions/appActions';
 
 const Refresher: React.FC<{ onRefresh?: () => void }> = ({ onRefresh }) => {
   const dispatch = useDispatch();
@@ -12,7 +12,7 @@ const Refresher: React.FC<{ onRefresh?: () => void }> = ({ onRefresh }) => {
     <IonRefresher
       slot="fixed"
       onIonRefresh={e => {
-        dispatch(update());
+        dispatch(updateState());
         if (onRefresh) onRefresh();
         setTimeout(() => e.detail.complete(), 2000);
       }}

--- a/src/pages/PinSetting/index.tsx
+++ b/src/pages/PinSetting/index.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../utils/errors';
 import {
   clearStorage,
+  getIdentity,
   setMnemonicInSecureStorage,
 } from '../../utils/storage-helper';
 
@@ -194,9 +195,15 @@ const PinSetting: React.FC<RouteComponentProps> = ({ history }) => {
                     onClick={() => {
                       if (isPinValidated && isTermsAccepted) {
                         setLoading(true);
-                        dispatch(signIn(firstPin));
-                        setIsWrongPin(null);
-                        history.push('/wallet');
+                        getIdentity(firstPin)
+                          .then(mnemonic => {
+                            setIsWrongPin(null);
+                            setLoading(false);
+                            // setIsAuth will cause redirect to /wallet
+                            // Restore state
+                            dispatch(signIn(mnemonic));
+                          })
+                          .catch(console.error);
                       }
                     }}
                   >

--- a/src/pages/Tabs/index.tsx
+++ b/src/pages/Tabs/index.tsx
@@ -47,6 +47,7 @@ const Tabs: React.FC<RouteComponentProps> = ({ history, location }) => {
             <Redirect exact from="/login" to="/wallet" />
             <Redirect exact from="/homescreen" to="/wallet" />
             <Redirect exact from="/restore" to="/wallet" />
+            <Redirect exact from="/onboarding/pin-setting" to="/wallet" />
           </IonRouterOutlet>
           <IonTabBar slot="bottom">
             {TABS.map((item, index) => (

--- a/src/pages/Wallet/index.tsx
+++ b/src/pages/Wallet/index.tsx
@@ -5,7 +5,6 @@ import {
   IonPage,
   IonListHeader,
   IonButton,
-  useIonViewWillEnter,
   IonIcon,
   IonGrid,
   IonRow,
@@ -22,8 +21,6 @@ import Header from '../../components/Header';
 import Refresher from '../../components/Refresher';
 import { CurrencyIcon } from '../../components/icons';
 import type { BalanceInterface } from '../../redux/actionTypes/walletActionTypes';
-import { update } from '../../redux/actions/appActions';
-import { updateUtxos } from '../../redux/actions/walletActions';
 import { network } from '../../redux/config';
 import type { AssetConfig } from '../../utils/constants';
 import {
@@ -54,7 +51,6 @@ const Wallet: React.FC<WalletProps> = ({
   prices,
   currency,
   history,
-  dispatch,
   totalLBTC,
 }) => {
   const lbtcUnit = useSelector((state: any) => state.settings.denominationLBTC);
@@ -88,8 +84,6 @@ const Wallet: React.FC<WalletProps> = ({
     });
     return assets;
   };
-
-  useIonViewWillEnter(() => dispatch(updateUtxos()));
 
   useEffect(() => {
     const fiatsValues = balances.map(({ amount, coinGeckoID }) => {
@@ -143,10 +137,6 @@ const Wallet: React.FC<WalletProps> = ({
     setDepositAssets(getDepositAssets());
   }, [balances]);
 
-  useEffect(() => {
-    dispatch(update());
-  }, []);
-
   return (
     <IonPage>
       <IonContent className="wallet-content">
@@ -166,7 +156,7 @@ const Wallet: React.FC<WalletProps> = ({
                   ? `${(
                       fromSatoshi(totalLBTC.amount) * prices[LBTC_COINGECKOID]
                     ).toFixed(2)} ${currency.toUpperCase()}`
-                  : undefined
+                  : `0.00 ${currency.toUpperCase()}`
               }
             />
           </IonRow>

--- a/src/redux/actions/appActions.ts
+++ b/src/redux/actions/appActions.ts
@@ -1,3 +1,5 @@
+import type { Mnemonic } from 'ldk';
+
 import type { ActionType } from '../../utils/types';
 
 export const INIT_APP = 'INIT_APP';
@@ -15,7 +17,7 @@ export const setIsBackupDone = (done: boolean): ActionType => {
   };
 };
 
-export const update = (): ActionType => {
+export const updateState = (): ActionType => {
   return {
     type: UPDATE,
   };
@@ -46,9 +48,9 @@ export const setSignedUp = (signedUp: boolean): ActionType => {
   };
 };
 
-export const signIn = (pin: string): ActionType => {
+export const signIn = (mnemonic: Mnemonic): ActionType => {
   return {
     type: SIGN_IN,
-    payload: pin,
+    payload: { mnemonic },
   };
 };


### PR DESCRIPTION
Extract getIdentity from signIn saga to have more flexibility.
getIdentity checks pin / mnemonic validity, then signIn saga set `isAuth` to true (which causes redirect to /wallet) and start restoration and state update process. 

Order of calls have been modified so that we redirect to `/wallet` right away and restoration start in the background.

Please review @tiero @louisinger 
