### PR TITLE
Bump tdex-sdk to 1.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "redux-saga": "^1.1.3",
     "reselect": "^4.0.0",
     "scrypt-js": "^3.0.1",
-    "tdex-sdk": "1.6.10"
+    "tdex-sdk": "^1.6.11"
   },
   "devDependencies": {
     "@babel/core": "^7.14.5",

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@ionic/react';
 import classNames from 'classnames';
 import type { UtxoInterface } from 'ldk';
+import { mnemonicRestorerFromState } from 'ldk';
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import type { RouteComponentProps } from 'react-router';
@@ -34,6 +35,7 @@ import {
 import { watchTransaction } from '../../redux/actions/transactionsActions';
 import { unlockUtxos } from '../../redux/actions/walletActions';
 import ExchangeRow from '../../redux/containers/exchangeRowContainer';
+import { lastUsedIndexesSelector } from '../../redux/selectors/walletSelectors';
 import type { AssetConfig } from '../../utils/constants';
 import {
   defaultPrecision,
@@ -50,7 +52,8 @@ import {
   getAssetHashLBTC,
   toSatoshi,
 } from '../../utils/helpers';
-import { getConnectedIdentity } from '../../utils/storage-helper';
+import type { TDexMnemonicRedux } from '../../utils/identity';
+import { getConnectedTDexMnemonic } from '../../utils/storage-helper';
 import type { AssetWithTicker } from '../../utils/tdex';
 import { allTrades, makeTrade, getTradablesAssets } from '../../utils/tdex';
 import type { PreviewData } from '../TradeSummary';
@@ -102,6 +105,8 @@ const Exchange: React.FC<ExchangeProps> = ({
   const [modalOpen, setModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [isWrongPin, setIsWrongPin] = useState<boolean | null>(null);
+
+  const lastUsedIndexes = useSelector(lastUsedIndexesSelector);
 
   const checkAvailableAmountSent = () => {
     if (!trade || !sentAmount || !assetSent) return;
@@ -195,7 +200,10 @@ const Exchange: React.FC<ExchangeProps> = ({
       setLoading(true);
       let identity;
       try {
-        identity = await getConnectedIdentity(pin, dispatch);
+        const toRestore = await getConnectedTDexMnemonic(pin, dispatch);
+        identity = (await mnemonicRestorerFromState(toRestore)(
+          lastUsedIndexes,
+        )) as TDexMnemonicRedux;
         setIsWrongPin(false);
         setTimeout(() => {
           setIsWrongPin(null);

--- a/src/utils/identity.ts
+++ b/src/utils/identity.ts
@@ -2,7 +2,7 @@ import type { AddressInterface, IdentityInterface, IdentityOpts } from 'ldk';
 import { Mnemonic } from 'ldk';
 import type { Dispatch } from 'redux';
 import { TDEXMnemonic } from 'tdex-sdk';
-import type { MnemonicOpts } from 'tdex-sdk'
+import type { MnemonicOpts } from 'tdex-sdk';
 
 import { addAddress, watchUtxo } from '../redux/actions/walletActions';
 

--- a/src/utils/identity.ts
+++ b/src/utils/identity.ts
@@ -1,12 +1,36 @@
 import type { AddressInterface, IdentityInterface, IdentityOpts } from 'ldk';
 import { Mnemonic } from 'ldk';
 import type { Dispatch } from 'redux';
-import type { MnemonicOpts } from 'tdex-sdk';
+import { TDEXMnemonic } from 'tdex-sdk';
+import type { MnemonicOpts } from 'tdex-sdk'
 
 import { addAddress, watchUtxo } from '../redux/actions/walletActions';
 
 // Used when coins will be received
 export class MnemonicRedux extends Mnemonic implements IdentityInterface {
+  private readonly dispatch: Dispatch;
+
+  constructor(args: IdentityOpts<MnemonicOpts>, dispatch: Dispatch) {
+    super(args);
+    this.dispatch = dispatch;
+  }
+
+  async getNextAddress(): Promise<AddressInterface> {
+    const nextAddr = await super.getNextAddress();
+    this.dispatch(addAddress(nextAddr));
+    this.dispatch(watchUtxo(nextAddr));
+    return nextAddr;
+  }
+
+  async getNextChangeAddress(): Promise<AddressInterface> {
+    const nextAddr = await super.getNextChangeAddress();
+    this.dispatch(addAddress(nextAddr));
+    this.dispatch(watchUtxo(nextAddr));
+    return nextAddr;
+  }
+}
+
+export class TDexMnemonicRedux extends TDEXMnemonic {
   private readonly dispatch: Dispatch;
 
   constructor(args: IdentityOpts<MnemonicOpts>, dispatch: Dispatch) {

--- a/src/utils/storage-helper.ts
+++ b/src/utils/storage-helper.ts
@@ -5,6 +5,7 @@ import { IdentityType, Mnemonic } from 'ldk';
 import type { AddressInterface, TxInterface, UtxoInterface } from 'ldk';
 import type { StateRestorerOpts } from 'ldk/dist/restorer/mnemonic-restorer';
 import type { Dispatch } from 'redux';
+import type { TDEXMnemonic } from 'tdex-sdk';
 
 import type { TDEXProvider } from '../redux/actionTypes/tdexActionTypes';
 import { network } from '../redux/config';
@@ -14,7 +15,7 @@ import type { AssetConfig } from './constants';
 import { CURRENCIES, LBTC_DENOMINATIONS } from './constants';
 import type { Encrypted } from './crypto';
 import { decrypt, encrypt } from './crypto';
-import { MnemonicRedux } from './identity';
+import { MnemonicRedux, TDexMnemonicRedux } from './identity';
 
 const MNEMONIC_KEY = 'tdex-app-mnemonic';
 const ADDRESSES_KEY = 'tdex-app-addresses';
@@ -249,6 +250,23 @@ export async function getConnectedIdentity(
 ): Promise<MnemonicRedux> {
   const toRestoreMnemonic = await getMnemonicFromSecureStorage(pin);
   return new MnemonicRedux(
+    {
+      chain: network.chain,
+      type: IdentityType.Mnemonic,
+      opts: {
+        mnemonic: toRestoreMnemonic,
+      },
+    },
+    dispatch,
+  );
+}
+
+export async function getConnectedTDexMnemonic(
+  pin: string,
+  dispatch: Dispatch,
+): Promise<TDEXMnemonic> {
+  const toRestoreMnemonic = await getMnemonicFromSecureStorage(pin);
+  return new TDexMnemonicRedux(
     {
       chain: network.chain,
       type: IdentityType.Mnemonic,

--- a/src/utils/tdex.ts
+++ b/src/utils/tdex.ts
@@ -1,9 +1,7 @@
 import axios from 'axios';
 import type { CoinSelector, UtxoInterface } from 'ldk';
 import { Trade, TraderClient, TradeType } from 'tdex-sdk';
-import type {
-  TDEXMnemonic
-} from 'tdex-sdk';
+import type { TDEXMnemonic } from 'tdex-sdk';
 
 import type {
   TDEXTrade,

--- a/src/utils/tdex.ts
+++ b/src/utils/tdex.ts
@@ -1,6 +1,9 @@
 import axios from 'axios';
-import type { CoinSelector, IdentityInterface, UtxoInterface } from 'ldk';
+import type { CoinSelector, UtxoInterface } from 'ldk';
 import { Trade, TraderClient, TradeType } from 'tdex-sdk';
+import type {
+  TDEXMnemonic
+} from 'tdex-sdk';
 
 import type {
   TDEXTrade,
@@ -125,7 +128,7 @@ export async function makeTrade(
   known: { amount: number; asset: string },
   explorerUrl: string,
   utxos: UtxoInterface[],
-  identity: IdentityInterface,
+  identity: TDEXMnemonic,
   coinSelector: CoinSelector,
 ): Promise<string> {
   const trader = new Trade({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,10 +1336,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@grpc/grpc-js@^1.0.4":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.3.2.tgz#eae97e6daf5abd49a7818aadeca0744dfb1ebca1"
-  integrity sha512-UXepkOKCATJrhHGsxt+CGfpZy9zUn1q9mop5kfcXq1fBkTePxVNPOdnISlCbJFlCtld+pSLGyZCzr9/zVprFKA==
+"@grpc/grpc-js@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.3.3.tgz#479764be3044f44c9fe38702643f59ea1a5374cb"
+  integrity sha512-KkKZrX3fVTBYCtUk8I+Y4xWaauEEOIR1mIGoPFUK8C+a9TTub5dmjowJpFGz0dqYj//wJcgVR9fqpoNhSYFfHQ==
   dependencies:
     "@types/node" ">=12.12.47"
 
@@ -2146,7 +2146,7 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/google-protobuf@^3.7.2":
+"@types/google-protobuf@^3.15.2":
   version "3.15.2"
   resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.2.tgz#70753e948cabeb416d71299dc35c3f562a10fb0f"
   integrity sha512-ubeqvw7sl6CdgeiIilsXB2jIFoD/D0F+/LIEp7xEBEXRNtDJcf05FRINybsJtL7GlkWOUVn6gJs2W9OF+xI6lg==
@@ -3344,6 +3344,11 @@ bindings@^1.3.0, bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bip174-liquid@^1.0.1-liquid:
+  version "1.0.1-liquid.revert1"
+  resolved "https://registry.yarnpkg.com/bip174-liquid/-/bip174-liquid-1.0.1-liquid.revert1.tgz#16be96813066207a095979ac0648a14cafc73110"
+  integrity sha512-rvosIa9LmoWTHMuSRch44Iufs9YTii7Z9H1PWXKuYZtijFeNpIm/RmdF7+VcX9USwEZDOw9iPCysZN2rAb9kVw==
+
 bip174@vulpemventures/bip174.git:
   version "1.0.1"
   resolved "https://codeload.github.com/vulpemventures/bip174/tar.gz/32811dd32788e97059b3b978b19228156c3a3d64"
@@ -3361,7 +3366,7 @@ bip32@^2.0.4, bip32@^2.0.6:
     typeforce "^1.11.5"
     wif "^2.0.6"
 
-bip39@^3.0.2, bip39@^3.0.3:
+bip39@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
   integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
@@ -3392,7 +3397,7 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blech32@vulpemventures/blech32.git:
+"blech32@github:vulpemventures/blech32", blech32@vulpemventures/blech32.git:
   version "1.0.0"
   resolved "https://codeload.github.com/vulpemventures/blech32/tar.gz/1c9acd89bdd2a2a5016fb942cf7d898579f84c8d"
 
@@ -6214,7 +6219,7 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-google-protobuf@^3.11.4:
+google-protobuf@^3.17.3:
   version "3.17.3"
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.17.3.tgz#f87595073545a77946c8f0b67c302c5f7646d700"
   integrity sha512-OVPzcSWIAJ+d5yiHyeaLrdufQtrvaBrF4JQg+z8ynTkbO3uFcujqXszTumqg1cGsAsjkWnI+M5B1xZ19yR4Wyg==
@@ -7802,16 +7807,16 @@ last-call-webpack-plugin@^3.0.0:
     lodash "^4.17.5"
     webpack-sources "^1.1.0"
 
-ldk@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/ldk/-/ldk-0.3.4.tgz#53d7df73676bb7aa28a64bb6fbe499c5dababa2a"
-  integrity sha512-pw9nvS24w8+reWMRCmrzcOgA5hUST5z6LLSxJfN2ROfElh3beANg2mAiAUYmppd7eODJLCGqFc+oUi0L99gmpw==
+ldk@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/ldk/-/ldk-0.3.5.tgz#c4a3dfac60a6e2b526b3834de01dd5892a7906b8"
+  integrity sha512-zzGwZEifdRYNOGaYD2rKwNPn+nGdE7Vxc4fyXtrZRnxLqJ2OxIHa8nhLktvRpovtC5Y9O12d0Bj3karzeClCPg==
   dependencies:
     axios "^0.21.1"
     bip32 "^2.0.6"
     bip39 "^3.0.3"
     bs58check "^2.1.2"
-    liquidjs-lib "5.1.12"
+    liquidjs-lib "^5.1.13"
     marina-provider "^1.0.0"
     slip77 "^0.1.1"
 
@@ -7850,7 +7855,7 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-liquidjs-lib@5.1.12, liquidjs-lib@^5.1.12, liquidjs-lib@^5.1.7:
+liquidjs-lib@^5.1.12:
   version "5.1.12"
   resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-5.1.12.tgz#4ab22d9c9ae5514b647eb4b011d76d13f1a097dd"
   integrity sha512-v01gO9zokMzQ4qRQ/ts5POgTL1ACZUqYgGWC/GE9oe1YXwnSdkho6m4M1zDOJLFwuew2DJ+RcQW8sFNMnHvWwA==
@@ -7858,6 +7863,29 @@ liquidjs-lib@5.1.12, liquidjs-lib@^5.1.12, liquidjs-lib@^5.1.7:
     "@vulpemventures/secp256k1-zkp" "^2.0.0"
     bech32 "^1.1.2"
     bip174 vulpemventures/bip174.git
+    bip32 "^2.0.4"
+    bip66 "^1.1.0"
+    bitcoin-ops "^1.4.0"
+    blech32 vulpemventures/blech32.git
+    bs58check "^2.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.3"
+    merkle-lib "^2.0.10"
+    pushdata-bitcoin "^1.0.1"
+    randombytes "^2.0.1"
+    tiny-secp256k1 "^1.1.1"
+    typeforce "^1.11.3"
+    varuint-bitcoin "^1.0.4"
+    wif "^2.0.1"
+
+liquidjs-lib@^5.1.13:
+  version "5.1.13"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-5.1.13.tgz#3a3d8f8951ac5daf943056c8b2be3db007a738d8"
+  integrity sha512-36S30HKdJxd/8+pNdkuZS6EmH0C3gvDk379KGWtUKRvyVY1ku046tMbJT3n7s8a6zwzmA62EsP8HDNAA/h21DA==
+  dependencies:
+    "@vulpemventures/secp256k1-zkp" "^2.0.0"
+    bech32 "^1.1.2"
+    bip174-liquid "^1.0.1-liquid"
     bip32 "^2.0.4"
     bip66 "^1.1.0"
     bitcoin-ops "^1.4.0"
@@ -11986,23 +12014,19 @@ tdex-react-scripts@4.0.3-tdex:
   optionalDependencies:
     fsevents "^2.1.3"
 
-tdex-sdk@1.6.10:
-  version "1.6.10"
-  resolved "https://registry.yarnpkg.com/tdex-sdk/-/tdex-sdk-1.6.10.tgz#63500e0a43eb89db21cd4decc84775e3bf32478b"
-  integrity sha512-lZq5cpL2Pmuavfd15EjhBOPUWrK8PDB/obosg6lQH8PvOvGEQ8wgq9tmJjGTHU2BfwMUatQJ6sm/F0A2EH/9GQ==
+tdex-sdk@^1.6.11:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/tdex-sdk/-/tdex-sdk-1.6.11.tgz#b4fb6ee9381c491c48538ca241a108b9840825fa"
+  integrity sha512-DxwULeu0jGssx4qewHjTsWjx7pkJadfDh3EgD1k2Ww60iY4rv/6fEKGjVrH+sDtHrx2d8busSVuAmKpbpZ1BQA==
   dependencies:
-    "@grpc/grpc-js" "^1.0.4"
-    "@types/google-protobuf" "^3.7.2"
-    axios "^0.21.1"
-    bip32 "^2.0.6"
-    bip39 "^3.0.2"
-    bs58check "^2.1.2"
-    google-protobuf "^3.11.4"
-    ldk "^0.3.4"
-    liquidjs-lib "^5.1.7"
+    "@grpc/grpc-js" "^1.3.3"
+    "@types/google-protobuf" "^3.15.2"
+    google-protobuf "^3.17.3"
+    ldk "^0.3.5"
+    liquidjs-lib "^5.1.13"
     slip77 "^0.1.1"
     tdex-protobuf tdex-network/tdex-protobuf
-    tslib "^2.0.0"
+    tslib "^2.3.0"
 
 temp-dir@^1.0.0:
   version "1.0.0"
@@ -12267,7 +12291,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@*, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0:
+tslib@*, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==


### PR DESCRIPTION
**This PR bumps tdex-sdk 1.6.11 and updates the `makeTrade` function**

I duplicated the `MnemonicRedux` class in order to use the new `TDEXMnemonic` Identity in the `makeTrade` function.

tested on Android (mainnet) and regtest (web version). Need a test on iOS.

@tiero @Janaka-Steph please review