### PR TITLE
Fetch utxos state indicator

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@ionic/react';
 import classNames from 'classnames';
 import { chevronBackOutline, closeOutline } from 'ionicons/icons';
+import type { ReactElement } from 'react';
 import React from 'react';
 import './style.scss';
 
@@ -20,8 +21,7 @@ interface HeaderProps {
   hasBackButton: boolean;
   hasCloseButton?: boolean;
   title: string;
-  customRightButton?: string;
-  handleCustomRightButton?: () => void;
+  customRightButton?: ReactElement;
 }
 
 const Header: React.FC<HeaderProps> = ({
@@ -33,7 +33,6 @@ const Header: React.FC<HeaderProps> = ({
   isTitleLarge = false,
   title,
   customRightButton,
-  handleCustomRightButton,
 }) => {
   return (
     <IonHeader className="ion-no-border">
@@ -44,14 +43,7 @@ const Header: React.FC<HeaderProps> = ({
         })}
       >
         {customRightButton && hasCloseButton && (
-          <IonButtons slot="end">
-            <IonButton
-              className="custom-right-button"
-              onClick={handleCustomRightButton}
-            >
-              <img src={customRightButton} alt="custom" />
-            </IonButton>
-          </IonButtons>
+          <IonButtons slot="end">{customRightButton}</IonButtons>
         )}
         {!customRightButton && hasCloseButton && (
           <IonButtons slot="end">

--- a/src/components/Header/style.scss
+++ b/src/components/Header/style.scss
@@ -18,10 +18,12 @@ ion-header {
       right: 0;
       width: 30px;
     }
-    ion-button.custom-right-button {
-      filter: brightness(65%);
+    ion-buttons {
       position: absolute;
       right: 0;
+      filter: brightness(65%);
+    }
+    .custom-right-button {
       width: 65px;
       @media (max-width: 320px) {
         width: 55px;

--- a/src/components/Refresher/index.tsx
+++ b/src/components/Refresher/index.tsx
@@ -14,12 +14,13 @@ const Refresher: React.FC<{ onRefresh?: () => void }> = ({ onRefresh }) => {
       onIonRefresh={e => {
         dispatch(updateState());
         if (onRefresh) onRefresh();
-        setTimeout(() => e.detail.complete(), 2000);
+        // An other top-right spinner shows actual update state
+        setTimeout(() => e.detail.complete(), 1000);
       }}
     >
       <IonRefresherContent
         pullingIcon={chevronDownCircleOutline}
-        refreshingSpinner="circles"
+        refreshingSpinner="lines-small"
       />
     </IonRefresher>
   );

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -274,10 +274,14 @@ const Exchange: React.FC<ExchangeProps> = ({
             <Header
               hasBackButton={false}
               hasCloseButton={true}
-              customRightButton={tradeHistory}
-              handleCustomRightButton={() => {
-                history.push('/history');
-              }}
+              customRightButton={
+                <IonButton
+                  className="custom-right-button"
+                  onClick={() => history.push('/history')}
+                >
+                  <img src={tradeHistory} alt="trade history" />
+                </IonButton>
+              }
               title="Exchange"
               isTitleLarge={true}
             />

--- a/src/pages/Wallet/index.tsx
+++ b/src/pages/Wallet/index.tsx
@@ -9,6 +9,7 @@ import {
   IonGrid,
   IonRow,
   IonCol,
+  IonSpinner,
 } from '@ionic/react';
 import { addCircleOutline } from 'ionicons/icons';
 import React, { useEffect, useState } from 'react';
@@ -43,6 +44,7 @@ interface WalletProps extends RouteComponentProps {
   dispatch: (action: ActionType) => void;
   backupDone: boolean;
   totalLBTC: BalanceInterface;
+  isFetchingUtxos: boolean;
 }
 
 const Wallet: React.FC<WalletProps> = ({
@@ -52,6 +54,7 @@ const Wallet: React.FC<WalletProps> = ({
   currency,
   history,
   totalLBTC,
+  isFetchingUtxos,
 }) => {
   const lbtcUnit = useSelector((state: any) => state.settings.denominationLBTC);
   const [mainAssets, setMainAssets] = useState<BalanceInterface[]>([]);
@@ -142,7 +145,15 @@ const Wallet: React.FC<WalletProps> = ({
       <IonContent className="wallet-content">
         <Refresher />
         <IonGrid>
-          <Header title="Wallet" hasBackButton={false} isTitleLarge={true} />
+          <Header
+            title="Wallet"
+            hasCloseButton={true}
+            hasBackButton={false}
+            isTitleLarge={true}
+            customRightButton={
+              isFetchingUtxos ? <IonSpinner name="lines-small" /> : <></>
+            }
+          />
           <IonRow className="ion-margin-vertical ion-justify-content-center">
             <CircleTotalBalance
               totalBalance={

--- a/src/redux/actions/appActions.ts
+++ b/src/redux/actions/appActions.ts
@@ -8,6 +8,7 @@ export const INIT_APP_FAIL = 'INIT_APP_FAIL';
 export const SET_SIGNED_UP = 'SET_SIGNED_UP';
 export const SIGN_IN = 'SIGN_IN';
 export const UPDATE = 'UPDATE';
+export const SET_IS_FETCHING_UTXOS = 'SET_IS_FETCHING_UTXOS';
 export const SET_IS_BACKUP_DONE = 'SET_IS_BACKUP_DONE';
 
 export const setIsBackupDone = (done: boolean): ActionType => {
@@ -20,6 +21,13 @@ export const setIsBackupDone = (done: boolean): ActionType => {
 export const updateState = (): ActionType => {
   return {
     type: UPDATE,
+  };
+};
+
+export const setIsFetchingUtxos = (isFetchingUtxos: boolean): ActionType => {
+  return {
+    type: SET_IS_FETCHING_UTXOS,
+    payload: isFetchingUtxos,
   };
 };
 

--- a/src/redux/containers/walletContainer.tsx
+++ b/src/redux/containers/walletContainer.tsx
@@ -13,6 +13,7 @@ const mapStateToProps = (state: any) => {
     prices: state.rates.prices,
     currency: state.settings.currency.value,
     backupDone: state.app.backupDone,
+    isFetchingUtxos: state.app.isFetchingUtxos,
   };
 };
 

--- a/src/redux/reducers/appReducer.ts
+++ b/src/redux/reducers/appReducer.ts
@@ -3,6 +3,7 @@ import {
   INIT_APP_FAIL,
   INIT_APP_SUCCESS,
   SET_IS_BACKUP_DONE,
+  SET_IS_FETCHING_UTXOS,
   SET_SIGNED_UP,
 } from '../actions/appActions';
 
@@ -10,12 +11,14 @@ export interface AppState {
   appInit: boolean;
   isSignedUp: boolean;
   backupDone: boolean;
+  isFetchingUtxos: boolean;
 }
 
 const initialState: AppState = {
   appInit: false,
   isSignedUp: false,
   backupDone: false,
+  isFetchingUtxos: false,
 };
 
 function appReducer(state = initialState, action: ActionType): AppState {
@@ -35,6 +38,11 @@ function appReducer(state = initialState, action: ActionType): AppState {
       return {
         ...state,
         backupDone: action.payload,
+      };
+    case SET_IS_FETCHING_UTXOS:
+      return {
+        ...state,
+        isFetchingUtxos: action.payload,
       };
     default:
       return state;

--- a/src/redux/sagas/appSaga.ts
+++ b/src/redux/sagas/appSaga.ts
@@ -1,4 +1,11 @@
-import { takeLatest, put, call, all, select } from 'redux-saga/effects';
+import {
+  takeLatest,
+  takeLeading,
+  put,
+  call,
+  all,
+  select,
+} from 'redux-saga/effects';
 
 import { seedBackupFlag } from '../../utils/storage-helper';
 import type { ActionType } from '../../utils/types';
@@ -10,6 +17,7 @@ import {
   SIGN_IN,
   UPDATE,
   setIsBackupDone,
+  setIsFetchingUtxos,
 } from '../actions/appActions';
 import { updatePrices } from '../actions/ratesActions';
 import { updateMarkets } from '../actions/tdexActions';
@@ -41,6 +49,7 @@ function* signInSaga(action: ActionType) {
     const backup = yield call(seedBackupFlag);
     if (backup) yield put(setIsBackupDone(true));
     // Wallet Restoration
+    yield setIsFetchingUtxos(true);
     const explorerUrl = yield select(
       (state: any) => state.settings.explorerUrl,
     );
@@ -62,6 +71,7 @@ function* signInSaga(action: ActionType) {
 
 // Triggered by <Refresher />
 function* updateState() {
+  yield put(setIsFetchingUtxos(true));
   yield all([
     put(updateMarkets()),
     put(updateTransactions()),
@@ -73,5 +83,5 @@ function* updateState() {
 export function* appWatcherSaga(): Generator<any, any, any> {
   yield takeLatest(INIT_APP, initAppSaga);
   yield takeLatest(SIGN_IN, signInSaga);
-  yield takeLatest(UPDATE, updateState);
+  yield takeLeading(UPDATE, updateState);
 }

--- a/src/redux/sagas/walletSaga.ts
+++ b/src/redux/sagas/walletSaga.ts
@@ -22,8 +22,7 @@ import {
   setUtxosInStorage,
 } from '../../utils/storage-helper';
 import type { ActionType } from '../../utils/types';
-import { SIGN_IN } from '../actions/appActions';
-import { updatePrices } from '../actions/ratesActions';
+import { setIsFetchingUtxos, SIGN_IN } from '../actions/appActions';
 import { addErrorToast } from '../actions/toastActions';
 import {
   UPDATE_UTXOS,
@@ -64,7 +63,6 @@ function* updateUtxosState() {
       select(({ wallet }: { wallet: WalletState }) => wallet.utxos),
       select(({ settings }) => settings.explorerUrl),
     ]);
-    yield put(updatePrices());
     yield call(fetchAndUpdateUtxos, addresses, utxos, explorerURL);
   } catch (error) {
     console.error(error);
@@ -118,6 +116,7 @@ export function* fetchAndUpdateUtxos(
   if (utxoUpdatedCount > 0) {
     console.debug(`${utxoUpdatedCount} utxos updated`);
   }
+  yield put(setIsFetchingUtxos(false));
 }
 
 function* waitAndUnlock({ payload }: { payload: string }) {

--- a/src/theme/components/ionic/index.scss
+++ b/src/theme/components/ionic/index.scss
@@ -3,3 +3,4 @@
 @import './ion-item.scss';
 @import './ion-list-header.scss';
 @import './ion-modal.scss';
+@import './ion-refresher.scss';

--- a/src/theme/components/ionic/ion-refresher.scss
+++ b/src/theme/components/ionic/ion-refresher.scss
@@ -1,0 +1,3 @@
+ion-refresher {
+	filter: brightness(65%);
+}

--- a/src/utils/storage-helper.ts
+++ b/src/utils/storage-helper.ts
@@ -143,7 +143,7 @@ export function setLastUsedIndexesInStorage(
   });
 }
 
-export async function getLastUsedIndexesInStorage(): Promise<StateRestorerOpts> {
+export async function getLastUsedIndexesInStorage(): Promise<StateRestorerOpts | null> {
   const idx = await Storage.get({ key: LAST_USED_INDEXES_KEY });
   return idx.value ? parse(idx.value) : null;
 }


### PR DESCRIPTION
New spinner top-right on main Wallet page to indicate utxos fetching.
Set state to true after successful login and when manually refreshing.
Set state to false when utxos have been fetched.

The spinner of manual refreshing has been shorten to 1 sec because it doesn't indicate the real fetching state.

Refresher component calls the Update saga, which is now takeLeading to avoid restarting it from the start when another pull down occurs. Saga is now triggered only when no saga is active.   

It closes #296 

Please review @tiero 