### PR TITLE
If pin error, redirect to first pin screen

### DIFF
--- a/src/pages/RestoreWallet/index.tsx
+++ b/src/pages/RestoreWallet/index.tsx
@@ -115,9 +115,11 @@ const RestoreWallet: React.FC<RestoreWalletProps> = ({
     clearStorage().catch(console.error);
     dispatch(addErrorToast(e));
     setIsWrongPin(true);
+    setLoading(false);
+    setFirstPin('');
     setTimeout(() => {
+      setModalOpen('first');
       setIsWrongPin(null);
-      setFirstPin('');
       setNeedReset(true);
     }, PIN_TIMEOUT_FAILURE);
   };


### PR DESCRIPTION
At wallet restoration, if pin error, redirect to first pin screen.
Fix bug on restoration where if pin doesn't match first time they will never match.

Please review @tiero 