### PR TITLE
Fix delete mnemonic modal flickering

### DIFF
--- a/src/pages/Account/index.tsx
+++ b/src/pages/Account/index.tsx
@@ -47,8 +47,8 @@ const Account: React.FC<RouteComponentProps> = ({ history }) => {
     getMnemonicFromSecureStorage(pin)
       .then(mnemonic => {
         setIsWrongPin(false);
+        setPinNeedReset(true);
         setTimeout(() => {
-          setPinModalOpen(false);
           setIsWrongPin(null);
           if (routeToGo === '/settings/show-mnemonic') {
             history.replace({


### PR DESCRIPTION
After successful pin to enter delete mnemonic page, `setPinModalOpen(false)` was called before transitioning to the page, resulting in a flickering. Remove this call. Also add `setPinNeedReset(true)` to clean the state and avoid `Can't perform a React state update on an unmounted component` warning. 