### PR TITLE
Fix asset precision

### DIFF
--- a/src/components/ExchangeRow/index.tsx
+++ b/src/components/ExchangeRow/index.tsx
@@ -148,7 +148,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
           {
             amount: relatedAssetAmount,
             asset: relatedAssetHash,
-            precision: assets[relatedAssetHash]?.precision || defaultPrecision,
+            precision: assets[relatedAssetHash]?.precision ?? defaultPrecision,
           },
           trades,
           lbtcUnit,
@@ -163,7 +163,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
           {
             amount: relatedAssetAmount,
             asset: relatedAssetHash,
-            precision: assets[relatedAssetHash]?.precision || defaultPrecision,
+            precision: assets[relatedAssetHash]?.precision ?? defaultPrecision,
           },
           newTrade,
           lbtcUnit,
@@ -172,7 +172,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
         //
         if (isLbtc(asset.asset)) {
           const precision =
-            assets[priceInSats.asset]?.precision || defaultPrecision;
+            assets[priceInSats.asset]?.precision ?? defaultPrecision;
           updatedAmount = fromSatoshiFixed(
             priceInSats.amount.toString(),
             precision,
@@ -183,7 +183,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
           // Convert fiat
           const priceInBtc = fromSatoshi(
             priceInSats.amount.toString(),
-            assets[priceInSats.asset]?.precision || defaultPrecision,
+            assets[priceInSats.asset]?.precision ?? defaultPrecision,
             lbtcUnit,
           );
           updatedAmount = toLBTCwithUnit(priceInBtc, lbtcUnit)
@@ -322,7 +322,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
               fromSatoshiFixed(
                 balance?.amount.toString() || '0',
                 balance?.precision,
-                balance?.precision || defaultPrecision,
+                balance?.precision ?? defaultPrecision,
                 balance?.ticker === 'L-BTC' ? lbtcUnit : undefined,
               ),
             );
@@ -332,7 +332,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
           <span>{`${fromSatoshiFixed(
             balance?.amount.toString() || '0',
             balance?.precision,
-            balance?.precision || defaultPrecision,
+            balance?.precision ?? defaultPrecision,
             balance?.ticker === 'L-BTC' ? lbtcUnit : undefined,
           )} ${balance?.ticker === 'L-BTC' ? lbtcUnit : asset.ticker}`}</span>
         </span>

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -121,7 +121,7 @@ const Exchange: React.FC<ExchangeProps> = ({
         : trade.market.baseAmount;
     const sats = toSatoshi(
       sentAmount,
-      assets[assetSent.asset]?.precision || defaultPrecision,
+      assets[assetSent.asset]?.precision ?? defaultPrecision,
       assetSent.ticker === 'L-BTC' ? lbtcUnit : undefined,
     );
     if (
@@ -143,7 +143,7 @@ const Exchange: React.FC<ExchangeProps> = ({
         : trade.market.quoteAmount;
     const sats = toSatoshi(
       receivedAmount,
-      assets[assetReceived.asset]?.precision || defaultPrecision,
+      assets[assetReceived.asset]?.precision ?? defaultPrecision,
       assetReceived.ticker === 'L-BTC' ? lbtcUnit : undefined,
     );
     if (
@@ -230,7 +230,7 @@ const Exchange: React.FC<ExchangeProps> = ({
         {
           amount: toSatoshi(
             sentAmount,
-            assets[assetSent.asset]?.precision || defaultPrecision,
+            assets[assetSent.asset]?.precision ?? defaultPrecision,
             isLbtc(assetSent.asset) ? lbtcUnit : undefined,
           ).toNumber(),
           asset: assetSent.asset,

--- a/src/pages/Operations/index.tsx
+++ b/src/pages/Operations/index.tsx
@@ -28,7 +28,11 @@ import { CurrencyIcon, TxIcon } from '../../components/icons';
 import type { BalanceInterface } from '../../redux/actionTypes/walletActionTypes';
 import WatchersLoader from '../../redux/containers/watchersLoaderContainer';
 import { transactionsByAssetSelector } from '../../redux/reducers/transactionsReducer';
-import { LBTC_TICKER, MAIN_ASSETS } from '../../utils/constants';
+import {
+  defaultPrecision,
+  LBTC_TICKER,
+  MAIN_ASSETS,
+} from '../../utils/constants';
 import {
   compareTxDisplayInterfaceByDate,
   fromSatoshi,
@@ -77,7 +81,7 @@ const Operations: React.FC<OperationsProps> = ({
         amount: 0,
         coinGeckoID: asset?.coinGeckoID ?? '',
         ticker: asset?.ticker ?? '',
-        precision: asset?.precision ?? 8,
+        precision: asset?.precision ?? defaultPrecision,
       });
     }
   }, [balances, asset_id]);
@@ -248,7 +252,7 @@ const Operations: React.FC<OperationsProps> = ({
                                             ? lbtcUnit
                                             : undefined,
                                         )
-                                      : 'unknow'}
+                                      : 'unknown'}
                                   </div>
                                   <div className="main-row accent">
                                     {balance.ticker === 'L-BTC'

--- a/src/redux/reducers/transactionsReducer.ts
+++ b/src/redux/reducers/transactionsReducer.ts
@@ -53,7 +53,7 @@ export const transactionsSelector = ({
   transactions: TransactionState;
 }): TxInterface[] => Object.values(transactions.txs);
 
-// meomized selector, map transactions to TxDisplayInterface[]
+// memoized selector, map transactions to TxDisplayInterface[]
 export const transactionsToDisplaySelector = createSelector(
   transactionsSelector,
   (state: any) => Object.keys(state.wallet.addresses),

--- a/src/redux/reducers/walletReducer.ts
+++ b/src/redux/reducers/walletReducer.ts
@@ -152,9 +152,9 @@ export const balancesSelector = (state: any): BalanceInterface[] => {
     balances.push({
       asset,
       amount: 0,
-      ticker: assets[asset]?.ticker || tickerFromAssetHash(asset),
+      ticker: assets[asset]?.ticker ?? tickerFromAssetHash(asset),
       coinGeckoID: getMainAsset(asset)?.coinGeckoID,
-      precision: assets[asset]?.precision || defaultPrecision,
+      precision: assets[asset]?.precision ?? defaultPrecision,
     });
   }
   return balances;

--- a/src/redux/sagas/assetsSaga.ts
+++ b/src/redux/sagas/assetsSaga.ts
@@ -53,7 +53,7 @@ async function getAssetData(
       await axios.get(`${explorerURL}/asset/${assetHash}`)
     ).data;
     return {
-      precision: precision || defaultPrecision,
+      precision: precision ?? defaultPrecision,
       ticker: ticker || tickerFromAssetHash(assetHash),
       name: name || '',
     };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -41,7 +41,7 @@ export function toSatoshi(
   unit?: string,
 ): Decimal {
   const v = new Decimal(val)
-    .mul(Decimal.pow(10, precision || defaultPrecision))
+    .mul(Decimal.pow(10, precision ?? defaultPrecision))
     .floor();
   return toLBTCwithUnit(v, unit);
 }
@@ -52,7 +52,7 @@ export function fromSatoshi(
   unit?: string,
 ): Decimal {
   const v = new Decimal(val).div(
-    Decimal.pow(10, precision || defaultPrecision),
+    Decimal.pow(10, precision ?? defaultPrecision),
   );
   return formatLBTCwithUnit(v, unit);
 }
@@ -184,7 +184,7 @@ export function balancesFromUtxos(
       amount,
       ticker: assets[asset]?.ticker || tickerFromAssetHash(asset),
       coinGeckoID,
-      precision: assets[asset]?.precision || defaultPrecision,
+      precision: assets[asset]?.precision ?? defaultPrecision,
     });
   }
 


### PR DESCRIPTION
Fix asset precision by not considering 0 a falsy value. 
Name and ticker are fetched correctly.

It closes #300 

Please review @tiero 