### PR TITLE
Prepare for Android release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ resources/ios/icon
 resources/ios/splash
 resources/windows/icon
 resources/windows/splash
+
+# keys
+*.keystore*

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,7 +6,7 @@ android {
         applicationId "io.sevenlabs.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
+        versionCode 2
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="io.sevenlabs.app">
 
+    <supports-screens android:smallScreens="true"
+                      android:normalScreens="true"
+                      android:largeScreens="false"
+                      android:xlargeScreens="false"/>
+
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/ionic.config.json
+++ b/ionic.config.json
@@ -1,5 +1,5 @@
 {
-  "name": "tdex-app",
+  "name": "TDEX",
   "integrations": {
     "capacitor": {}
   },

--- a/scripts/android-apk.sh
+++ b/scripts/android-apk.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Build
+cd android
+chmod +x ./gradlew
+./gradlew assemble
+cd ..
+
+# Sign
+apksigner sign \
+  --ks ./tdex-app-release-key.keystore \
+  --out ./android/app/build/outputs/apk/release/app-release-signed.apk \
+  ./android/app/build/outputs/apk/release/app-release-unsigned.apk


### PR DESCRIPTION
This adds a script to build debug and release APK locally and sign it with a key that should be placed in the root project directory called `tdex-app-release-key.keystore`
﻿
