### PR TITLE
Fix delay after confirming trade

### DIFF
--- a/src/redux/containers/exchangeContainer.tsx
+++ b/src/redux/containers/exchangeContainer.tsx
@@ -4,6 +4,7 @@ import Exchange from '../../pages/Exchange';
 import { getTradablesAssets } from '../../utils/tdex';
 import { allAssets } from '../reducers/tdexReducer';
 import { balancesSelector, allUtxosSelector } from '../reducers/walletReducer';
+import { lastUsedIndexesSelector } from '../selectors/walletSelectors';
 
 const mapStateToProps = (state: any) => {
   return {
@@ -17,6 +18,7 @@ const mapStateToProps = (state: any) => {
     utxos: allUtxosSelector(state),
     assets: state.assets,
     allAssets: allAssets(state),
+    lastUsedIndexes: lastUsedIndexesSelector(state),
   };
 };
 


### PR DESCRIPTION
Loader has a delay of zero. 
Getting `lastUsedIndexes` from Redux Container instead of useSelector prevents re-renderings. 

Please review @tiero 