### PR TITLE
Recognise USDT withdrawal

### DIFF
--- a/src/redux/containers/withdrawalContainer.tsx
+++ b/src/redux/containers/withdrawalContainer.tsx
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 
 import Withdrawal from '../../pages/Withdrawal';
 import { allUtxosSelector, balancesSelector } from '../reducers/walletReducer';
+import { lastUsedIndexesSelector } from '../selectors/walletSelectors';
 
 const mapStateToProps = (state: any) => {
   return {
@@ -9,6 +10,7 @@ const mapStateToProps = (state: any) => {
     utxos: allUtxosSelector(state),
     prices: state.rates.prices,
     explorerURL: state.settings.explorerUrl,
+    lastUsedIndexes: lastUsedIndexesSelector(state),
   };
 };
 

--- a/src/redux/reducers/walletReducer.ts
+++ b/src/redux/reducers/walletReducer.ts
@@ -1,4 +1,5 @@
 import type { AddressInterface, UtxoInterface, Outpoint, Mnemonic } from 'ldk';
+import { createSelector } from 'reselect';
 
 import {
   defaultPrecision,
@@ -139,26 +140,31 @@ export const allUtxosSelector = ({
 /**
  * Redux selector returning balance interfaces array
  * @param state
+ * @returns BalanceInterface[]
  */
-export const balancesSelector = (state: any): BalanceInterface[] => {
-  const assets = state.assets;
-  const utxos = allUtxosSelector(state);
-  const txsAssets = transactionsAssets(state);
-  const balances = balancesFromUtxos(utxos, assets);
-  const balancesAssets = balances.map(b => b.asset);
-  for (const asset of txsAssets) {
-    if (balancesAssets.includes(asset)) continue;
-    // include a 'zero' balance if the user has previous transactions.
-    balances.push({
-      asset,
-      amount: 0,
-      ticker: assets[asset]?.ticker ?? tickerFromAssetHash(asset),
-      coinGeckoID: getMainAsset(asset)?.coinGeckoID,
-      precision: assets[asset]?.precision ?? defaultPrecision,
-    });
-  }
-  return balances;
-};
+export const balancesSelector = createSelector(
+  [
+    state => (state as any).assets,
+    state => allUtxosSelector(state as any),
+    state => transactionsAssets(state as any),
+  ],
+  (assets, utxos, txsAssets) => {
+    const balances = balancesFromUtxos(utxos, assets);
+    const balancesAssets = balances.map(b => b.asset);
+    for (const asset of txsAssets) {
+      if (balancesAssets.includes(asset)) continue;
+      // include a 'zero' balance if the user has previous transactions.
+      balances.push({
+        asset,
+        amount: 0,
+        ticker: assets[asset]?.ticker ?? tickerFromAssetHash(asset),
+        coinGeckoID: getMainAsset(asset)?.coinGeckoID,
+        precision: assets[asset]?.precision ?? defaultPrecision,
+      });
+    }
+    return balances;
+  },
+);
 
 /**
  * Redux selector returning the total LBTC balance (including featuring assets with CoinGecko support)

--- a/src/redux/transformers/transactionsTransformer.ts
+++ b/src/redux/transformers/transactionsTransformer.ts
@@ -16,14 +16,20 @@ function getTransfers(
   walletScripts: string[],
 ): Transfer[] {
   const transfers: Transfer[] = [];
+  let feeAmount: number;
+  let feeAsset: string;
 
   const addToTransfers = (amount: number, asset: string) => {
-    const transferIndex = transfers.findIndex(
-      t => t.asset.valueOf() === asset.valueOf(),
-    );
+    const transferIndex = transfers.findIndex(t => t.asset === asset);
 
     if (transferIndex >= 0) {
-      transfers[transferIndex].amount += amount;
+      const tmp = transfers[transferIndex].amount + amount;
+      // Check if the transfer is a fee output
+      if (Math.abs(tmp) === feeAmount && asset === feeAsset) {
+        transfers.splice(transferIndex, 1);
+        return;
+      }
+      transfers[transferIndex].amount = tmp;
       return;
     }
 
@@ -39,6 +45,19 @@ function getTransfers(
       walletScripts.includes(input.prevout.script)
     ) {
       addToTransfers(-1 * input.prevout.value, input.prevout.asset);
+    }
+  }
+
+  // Get fee output values
+  for (const output of vout) {
+    if (
+      !isBlindedOutputInterface(output) &&
+      output.script === '' &&
+      Number(output.assetBlinder) === 0 &&
+      Number(output.valueBlinder) === 0
+    ) {
+      feeAmount = output.value;
+      feeAsset = output.asset;
     }
   }
 


### PR DESCRIPTION
Recognise USDT withdrawal by not counting LBTC fee output as a transfer.

Also: 
- Fix Withdrawal page Loader.
- Improve balancesSelector efficiency, running half as much as the previous one.

It closes #332 

Please review @tiero 