### PR TITLE
Tap to copy tx explorer url in Tx history

### DIFF
--- a/src/pages/Receive/index.tsx
+++ b/src/pages/Receive/index.tsx
@@ -12,7 +12,7 @@ import {
 import { checkmarkOutline } from 'ionicons/icons';
 import type { AddressInterface, IdentityOpts } from 'ldk';
 import { IdentityType, MasterPublicKey } from 'ldk';
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { withRouter, useLocation } from 'react-router';
 import type { MasterPublicKeyOpts } from 'tdex-sdk';
@@ -42,7 +42,6 @@ const Receive: React.FC = () => {
   const [copied, setCopied] = useState(false);
   const [address, setAddress] = useState<AddressInterface>();
   const [loading, setLoading] = useState(false);
-  const addressRef: any = useRef(null);
   const dispatch = useDispatch();
   const { state } = useLocation<LocationState>();
   // Hack to prevent undefined state when hitting back button
@@ -96,21 +95,21 @@ const Receive: React.FC = () => {
       Clipboard.copy(address.confidentialAddress)
         .then(() => {
           setCopied(true);
-          dispatch(addSuccessToast('Address copied.'));
+          dispatch(addSuccessToast('Address copied'));
           setTimeout(() => {
             setCopied(false);
           }, 5000);
         })
         .catch(() => {
-          if (addressRef?.current) {
-            addressRef.current.select();
-            document.execCommand('copy');
-            setCopied(true);
-            dispatch(addSuccessToast('Address copied.'));
-            setTimeout(() => {
-              setCopied(false);
-            }, 10000);
-          }
+          // For web platform
+          navigator.clipboard
+            .writeText(address.confidentialAddress)
+            .catch(console.error);
+          setCopied(true);
+          dispatch(addSuccessToast('Address copied'));
+          setTimeout(() => {
+            setCopied(false);
+          }, 5000);
         });
     }
   };
@@ -147,7 +146,6 @@ const Receive: React.FC = () => {
               <input
                 readOnly
                 type="text"
-                ref={addressRef}
                 value={address?.confidentialAddress}
                 className="hidden-input"
               />

--- a/src/pages/Receive/style.scss
+++ b/src/pages/Receive/style.scss
@@ -20,6 +20,10 @@
   max-height: 0;
 }
 
+.conf-addr:focus-visible {
+  outline: 0;
+}
+
 .conf-addr.item-start {
   display: block;
   line-height: 30px;

--- a/src/pages/TradeHistory/index.tsx
+++ b/src/pages/TradeHistory/index.tsx
@@ -59,7 +59,9 @@ const TradeHistory: React.FC<TradeHistoryProps> = ({ swaps }) => {
       })
       .catch(() => {
         // For web platform
-        navigator.clipboard.writeText(txid).catch(console.error);
+        navigator.clipboard
+          .writeText(`https://blockstream.info/liquid/tx/${txid}`)
+          .catch(console.error);
         dispatch(addSuccessToast('Transaction Id copied'));
       });
   };

--- a/src/pages/TradeHistory/index.tsx
+++ b/src/pages/TradeHistory/index.tsx
@@ -1,3 +1,4 @@
+import { Clipboard } from '@ionic-native/clipboard';
 import {
   IonPage,
   IonContent,
@@ -14,14 +15,17 @@ import {
 import classNames from 'classnames';
 import { checkmarkOutline } from 'ionicons/icons';
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import type { RouteComponentProps } from 'react-router';
 import { withRouter } from 'react-router';
 
 import Header from '../../components/Header';
 import { CurrencyIcon } from '../../components/icons';
+import { addSuccessToast } from '../../redux/actions/toastActions';
 import { LBTC_TICKER } from '../../utils/constants';
 import { fromSatoshiFixed, tickerFromAssetHash } from '../../utils/helpers';
 import type { TxDisplayInterface } from '../../utils/types';
+
 import './style.scss';
 
 interface TradeHistoryProps extends RouteComponentProps {
@@ -29,6 +33,8 @@ interface TradeHistoryProps extends RouteComponentProps {
 }
 
 const TradeHistory: React.FC<TradeHistoryProps> = ({ swaps }) => {
+  const dispatch = useDispatch();
+
   const renderStatus: any = (status: string) => {
     return status === 'pending' ? (
       <div className="status pending">
@@ -44,6 +50,18 @@ const TradeHistory: React.FC<TradeHistoryProps> = ({ swaps }) => {
         CONFIRMED <IonIcon color="success" icon={checkmarkOutline} />
       </div>
     );
+  };
+
+  const copyTxId = (txid: string) => {
+    Clipboard.copy(txid)
+      .then(() => {
+        dispatch(addSuccessToast('Transaction Id copied'));
+      })
+      .catch(() => {
+        // For web platform
+        navigator.clipboard.writeText(txid).catch(console.error);
+        dispatch(addSuccessToast('Transaction Id copied'));
+      });
   };
 
   return (
@@ -127,8 +145,13 @@ const TradeHistory: React.FC<TradeHistoryProps> = ({ swaps }) => {
                           </IonText>
                         </div>
                         <div className="info-row">
-                          <IonLabel>TxID</IonLabel>
-                          <IonText>{transaction.txId}</IonText>
+                          <IonLabel>Id</IonLabel>
+                          <IonItem
+                            className="tx-item ion-text-right"
+                            onClick={() => copyTxId(transaction.txId)}
+                          >
+                            <IonText>{transaction.txId}</IonText>
+                          </IonItem>
                         </div>
                       </div>
                     </div>

--- a/src/pages/TradeHistory/style.scss
+++ b/src/pages/TradeHistory/style.scss
@@ -9,6 +9,18 @@
 		font-size: var(--ion-font-size-sub);
 	}
 	
+	.info-row {
+		align-items: baseline;
+	}
+	
+	ion-item.tx-item {
+		font-size: var(--ion-font-size-sub);
+		--padding-top: 0;
+		--padding-bottom: 0;
+		--padding-end: 0;
+		--padding-start: 0;
+	}
+	
 	.item-main-info {
 		align-items: end;
 		


### PR DESCRIPTION
Tap to copy TxId in Tx history.
Use Clipboard API instead of deprecated `document.execCommand()` for web platform.

It closes #338 

Please review @tiero 