### PR TITLE
Restrict PIN keyboard to 'tel' on Android

### DIFF
--- a/src/components/PinInput/index.tsx
+++ b/src/components/PinInput/index.tsx
@@ -1,4 +1,4 @@
-import { IonInput, IonGrid, IonRow, IonCol } from '@ionic/react';
+import { IonInput, IonGrid, IonRow, IonCol, isPlatform } from '@ionic/react';
 import classNames from 'classnames';
 import React, { useEffect } from 'react';
 
@@ -74,8 +74,8 @@ const PinInput: React.FC<PinInputProps> = ({
               ref={inputRef}
               enterkeyhint="done"
               onKeyDown={onPressEnterKeyFactory(on6digits)}
-              inputmode="numeric"
-              type="number"
+              inputmode={isPlatform('android') ? 'tel' : 'numeric'}
+              type={isPlatform('android') ? 'tel' : 'number'}
               value={pin}
               required={true}
               onIonChange={e => handleNewPinDigit(e.detail.value)}

--- a/src/components/PinInput/style.scss
+++ b/src/components/PinInput/style.scss
@@ -5,18 +5,18 @@
       position: absolute;
     }
     .pin-input {
-      width: 1.25rem;
-      height: 1.25rem;
+      width: 1rem;
+      height: 1rem;
       border-radius: 50%;
-      border: 0.125rem solid rgb(102, 102, 102);
+      border: 0.12rem solid rgb(102, 102, 102);
       margin: 0 auto;
       &.error {
         background-color: var(--ion-color-danger);
-        border: 0.125rem solid var(--ion-color-danger);
+        border: 0.12rem solid var(--ion-color-danger);
       }
       &.success {
         background-color: var(--ion-color-success);
-        border: 0.125rem solid var(--ion-color-success);
+        border: 0.12rem solid var(--ion-color-success);
       }
       &.filled {
         background-color: rgb(102, 102, 102);

--- a/src/pages/PinSetting/index.tsx
+++ b/src/pages/PinSetting/index.tsx
@@ -90,7 +90,7 @@ const PinSetting: React.FC<RouteComponentProps> = ({ history }) => {
           onError(PINsDoNotMatchError);
         }
       } else {
-        dispatch(addErrorToast(PinDigitsError));
+        onPinDigitsError(false);
       }
     } else {
       if (validRegexp.test(firstPin)) {
@@ -100,9 +100,22 @@ const PinSetting: React.FC<RouteComponentProps> = ({ history }) => {
           setIsWrongPin(null);
         }, PIN_TIMEOUT_SUCCESS);
       } else {
-        dispatch(addErrorToast(PinDigitsError));
+        onPinDigitsError(true);
       }
     }
+  };
+
+  const onPinDigitsError = (isFirstPin: boolean) => {
+    dispatch(addErrorToast(PinDigitsError));
+    setIsWrongPin(true);
+    setTimeout(() => {
+      setIsWrongPin(null);
+      if (isFirstPin) {
+        setFirstPin('');
+      } else {
+        setSecondPin('');
+      }
+    }, PIN_TIMEOUT_FAILURE);
   };
 
   const onError = (e: AppError) => {

--- a/src/pages/PinSetting/styles.scss
+++ b/src/pages/PinSetting/styles.scss
@@ -1,5 +1,7 @@
 #pin-setting-page {
 	.terms-label {
+		font-family: var(--ion-font-main);
+		font-size: var(--ion-font-size-sub);
 	 a {
 		 display: inline-block;
 	 }


### PR DESCRIPTION
It closes #367 
On PIN inputs, keyboard is numeric only on iOS but not on Android. Only found solution is to restrict Android keyboard to "tel". 

