### PR TITLE
Change iOS display name to TDEX

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>tdex-app</string>
+	<string>TDEX</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Change the user-visible name for the bundle, used by Siri and visible on the iOS Home screen.
https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundledisplayname

Please review @tiero 