### PR TITLE
[Exchange] No more than max decimal digits for respective unit

### DIFF
--- a/src/components/ExchangeRow/index.tsx
+++ b/src/components/ExchangeRow/index.tsx
@@ -12,13 +12,12 @@ import { Decimal } from 'decimal.js';
 import { chevronDownOutline } from 'ionicons/icons';
 import { debounce } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
 
 import type { TDEXTrade } from '../../redux/actionTypes/tdexActionTypes';
 import type { BalanceInterface } from '../../redux/actionTypes/walletActionTypes';
 import ExchangeSearch from '../../redux/containers/exchangeSearchContainer';
 import { defaultPrecision } from '../../utils/constants';
-import type { AssetConfig } from '../../utils/constants';
+import type { AssetConfig, LbtcDenomination } from '../../utils/constants';
 import {
   fromSatoshi,
   fromSatoshiFixed,
@@ -66,6 +65,7 @@ interface ExchangeRowInterface {
   setError: (msg: string) => void;
   setOtherInputError: (msg: string) => void;
   isLoading: boolean;
+  lbtcUnit: LbtcDenomination;
 }
 
 const ExchangeRow: React.FC<ExchangeRowInterface> = ({
@@ -90,8 +90,8 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
   setError,
   setOtherInputError,
   isLoading,
+  lbtcUnit,
 }) => {
-  const lbtcUnit = useSelector((state: any) => state.settings.denominationLBTC);
   const [balance, setBalance] = useState<BalanceInterface>();
   const [amount, setAmount] = useState('');
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -244,7 +244,11 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
         return;
       }
       // Sanitize
-      const sanitizedValue = sanitizeInputAmount(e.detail.value, setAmount);
+      const sanitizedValue = sanitizeInputAmount(
+        e.detail.value,
+        setAmount,
+        isLbtc(asset.asset) ? lbtcUnit : undefined,
+      );
       // Set
       setAmount(sanitizedValue);
       onChangeAmount(sanitizedValue);

--- a/src/components/WithdrawRow/index.tsx
+++ b/src/components/WithdrawRow/index.tsx
@@ -18,6 +18,7 @@ import { updatePrices } from '../../redux/actions/ratesActions';
 import {
   fromSatoshi,
   fromSatoshiFixed,
+  isLbtc,
   toLBTCwithUnit,
 } from '../../utils/helpers';
 import { sanitizeInputAmount } from '../../utils/input';
@@ -70,7 +71,7 @@ const WithdrawRow: React.FC<WithdrawRowInterface> = ({
         balance.amount.toString(),
         balance.precision,
         balance.precision,
-        balance.ticker === 'L-BTC' ? lbtcUnit : undefined,
+        isLbtc(balance.asset) ? lbtcUnit : undefined,
       ),
     );
   }, [lbtcUnit, balance.amount]);
@@ -85,7 +86,7 @@ const WithdrawRow: React.FC<WithdrawRowInterface> = ({
         balance.amount.toString(),
         balance.precision,
         balance.precision,
-        balance.ticker === 'L-BTC' ? lbtcUnit : undefined,
+        isLbtc(balance.asset) ? lbtcUnit : undefined,
       ),
     );
     if (price) setFiat('0.00');
@@ -97,14 +98,14 @@ const WithdrawRow: React.FC<WithdrawRowInterface> = ({
       reset();
       return;
     }
-
-    const sanitizedValue = sanitizeInputAmount(e.detail.value, setAmount);
+    const unit = isLbtc(balance.asset) ? lbtcUnit : undefined;
+    const sanitizedValue = sanitizeInputAmount(e.detail.value, setAmount, unit);
     // Set values
     setAmount(sanitizedValue);
     const residualAmount = fromSatoshi(
       balance.amount.toString(),
       balance.precision,
-      balance.ticker === 'L-BTC' ? lbtcUnit : undefined,
+      unit,
     ).sub(sanitizedValue);
     setResidualBalance(
       residualAmount.toNumber().toLocaleString('en-US', {
@@ -114,12 +115,7 @@ const WithdrawRow: React.FC<WithdrawRowInterface> = ({
     );
     if (price) {
       setFiat(
-        toLBTCwithUnit(
-          new Decimal(sanitizedValue),
-          balance.ticker === 'L-BTC' ? lbtcUnit : undefined,
-        )
-          .mul(price)
-          .toFixed(2),
+        toLBTCwithUnit(new Decimal(sanitizedValue), unit).mul(price).toFixed(2),
       );
     }
   };

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -12,7 +12,6 @@ import classNames from 'classnames';
 import type { UtxoInterface, StateRestorerOpts } from 'ldk';
 import { mnemonicRestorerFromState } from 'ldk';
 import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
 import type { RouteComponentProps } from 'react-router';
 import type { Dispatch } from 'redux';
 import { TradeType } from 'tdex-sdk';
@@ -35,7 +34,7 @@ import {
 import { watchTransaction } from '../../redux/actions/transactionsActions';
 import { unlockUtxos } from '../../redux/actions/walletActions';
 import ExchangeRow from '../../redux/containers/exchangeRowContainer';
-import type { AssetConfig } from '../../utils/constants';
+import type { AssetConfig, LbtcDenomination } from '../../utils/constants';
 import {
   defaultPrecision,
   PIN_TIMEOUT_FAILURE,
@@ -63,14 +62,15 @@ import './style.scss';
 const ERROR_LIQUIDITY = 'Not enough liquidity in market';
 
 interface ExchangeProps extends RouteComponentProps {
-  balances: BalanceInterface[];
-  utxos: UtxoInterface[];
-  explorerUrl: string;
-  markets: TDEXMarket[];
-  assets: Record<string, AssetConfig>;
   allAssets: AssetWithTicker[];
+  assets: Record<string, AssetConfig>;
+  balances: BalanceInterface[];
   dispatch: Dispatch;
+  explorerUrl: string;
   lastUsedIndexes: StateRestorerOpts;
+  lbtcUnit: LbtcDenomination;
+  markets: TDEXMarket[];
+  utxos: UtxoInterface[];
 }
 
 const Exchange: React.FC<ExchangeProps> = ({
@@ -83,8 +83,8 @@ const Exchange: React.FC<ExchangeProps> = ({
   allAssets,
   dispatch,
   lastUsedIndexes,
+  lbtcUnit,
 }) => {
-  const lbtcUnit = useSelector((state: any) => state.settings.denominationLBTC);
   const [hasBeenSwapped, setHasBeenSwapped] = useState<boolean>(false);
   // user inputs amount
   const [sentAmount, setSentAmount] = useState<string>();

--- a/src/pages/Operations/index.tsx
+++ b/src/pages/Operations/index.tsx
@@ -28,6 +28,7 @@ import { CurrencyIcon, TxIcon } from '../../components/icons';
 import type { BalanceInterface } from '../../redux/actionTypes/walletActionTypes';
 import WatchersLoader from '../../redux/containers/watchersLoaderContainer';
 import { transactionsByAssetSelector } from '../../redux/reducers/transactionsReducer';
+import type { LbtcDenomination } from '../../utils/constants';
 import {
   defaultPrecision,
   LBTC_TICKER,
@@ -52,7 +53,7 @@ interface OperationsProps extends RouteComponentProps {
   balances: BalanceInterface[];
   prices: Record<string, number>;
   currency: string;
-  lbtcUnit: string;
+  lbtcUnit: LbtcDenomination;
 }
 
 const Operations: React.FC<OperationsProps> = ({

--- a/src/redux/containers/exchangeContainer.tsx
+++ b/src/redux/containers/exchangeContainer.tsx
@@ -8,17 +8,18 @@ import { lastUsedIndexesSelector } from '../selectors/walletSelectors';
 
 const mapStateToProps = (state: any) => {
   return {
+    assets: state.assets,
+    allAssets: allAssets(state),
     balances: balancesSelector(state).filter(
       b =>
         b.amount > 0 &&
         getTradablesAssets(state.tdex.markets, b.asset).length > 0,
     ),
     explorerUrl: state.settings.explorerUrl,
+    lastUsedIndexes: lastUsedIndexesSelector(state),
+    lbtcUnit: state.settings.denominationLBTC,
     markets: state.tdex.markets,
     utxos: allUtxosSelector(state),
-    assets: state.assets,
-    allAssets: allAssets(state),
-    lastUsedIndexes: lastUsedIndexesSelector(state),
   };
 };
 

--- a/src/redux/containers/exchangeRowContainer.tsx
+++ b/src/redux/containers/exchangeRowContainer.tsx
@@ -5,10 +5,11 @@ import { balancesSelector } from '../reducers/walletReducer';
 
 const mapStateToProps = (state: any) => {
   return {
-    prices: state.rates.prices,
-    currency: state.settings.currency.value,
-    balances: balancesSelector(state),
     assets: state.assets,
+    balances: balancesSelector(state),
+    currency: state.settings.currency.value,
+    lbtcUnit: state.settings.denominationLBTC,
+    prices: state.rates.prices,
   };
 };
 

--- a/src/redux/reducers/settingsReducer.ts
+++ b/src/redux/reducers/settingsReducer.ts
@@ -1,3 +1,4 @@
+import type { LbtcDenomination } from '../../utils/constants';
 import { CURRENCIES, LBTC_DENOMINATIONS } from '../../utils/constants';
 import type { ActionType } from '../../utils/types';
 import {
@@ -18,7 +19,7 @@ export interface SettingsState {
   currency: CurrencyInterface;
   explorerUrl: string;
   theme: string;
-  denominationLBTC: string;
+  denominationLBTC: LbtcDenomination;
 }
 
 const initialState: SettingsState = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -115,7 +115,13 @@ export const CURRENCIES: CurrencyInterface[] = [
   },
 ];
 
-export const LBTC_DENOMINATIONS = ['L-BTC', 'L-mBTC', 'L-bits', 'L-sats'];
+export const LBTC_DENOMINATIONS = [
+  'L-BTC',
+  'L-mBTC',
+  'L-bits',
+  'L-sats',
+] as const;
+export type LbtcDenomination = typeof LBTC_DENOMINATIONS[number];
 
 export const TOAST_TIMEOUT_SUCCESS = 800;
 export const TOAST_TIMEOUT_FAILURE = 2000;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -19,7 +19,7 @@ import type { BalanceInterface } from '../redux/actionTypes/walletActionTypes';
 import { lockUtxo } from '../redux/actions/walletActions';
 import { network } from '../redux/config';
 
-import type { AssetConfig } from './constants';
+import type { AssetConfig, LbtcDenomination } from './constants';
 import { defaultPrecision, getColor, getMainAsset } from './constants';
 import type { TxDisplayInterface } from './types';
 
@@ -37,23 +37,20 @@ export const createColorFromHash = (id: string): string => {
 
 export function toSatoshi(
   val: string,
-  precision?: number,
-  unit?: string,
+  precision = defaultPrecision,
+  unit: LbtcDenomination = 'L-BTC',
 ): Decimal {
-  const v = new Decimal(val)
-    .mul(Decimal.pow(10, precision ?? defaultPrecision))
-    .floor();
-  return toLBTCwithUnit(v, unit);
+  return new Decimal(val).mul(
+    Decimal.pow(10, new Decimal(precision).minus(unitToExponent(unit))),
+  );
 }
 
 export function fromSatoshi(
   val: string,
-  precision?: number,
-  unit?: string,
+  precision = defaultPrecision,
+  unit: LbtcDenomination = 'L-BTC',
 ): Decimal {
-  const v = new Decimal(val).div(
-    Decimal.pow(10, precision ?? defaultPrecision),
-  );
+  const v = new Decimal(val).div(Decimal.pow(10, precision));
   return formatLBTCwithUnit(v, unit);
 }
 
@@ -61,7 +58,7 @@ export function fromSatoshiFixed(
   val: string,
   precision?: number,
   fixed?: number,
-  unit?: string,
+  unit?: LbtcDenomination,
 ): string {
   return formatLBTCwithUnit(fromSatoshi(val, precision), unit)
     .toNumber()
@@ -72,8 +69,10 @@ export function fromSatoshiFixed(
     });
 }
 
-export function toLBTCwithUnit(lbtcValue: Decimal, unit?: string): Decimal {
-  if (!unit) return lbtcValue;
+export function toLBTCwithUnit(
+  lbtcValue: Decimal,
+  unit?: LbtcDenomination,
+): Decimal {
   switch (unit) {
     case 'L-BTC':
       return lbtcValue;
@@ -88,8 +87,10 @@ export function toLBTCwithUnit(lbtcValue: Decimal, unit?: string): Decimal {
   }
 }
 
-export function formatLBTCwithUnit(lbtcValue: Decimal, unit?: string): Decimal {
-  if (!unit) return lbtcValue;
+export function formatLBTCwithUnit(
+  lbtcValue: Decimal,
+  unit?: LbtcDenomination,
+): Decimal {
   switch (unit) {
     case 'L-BTC':
       return lbtcValue;
@@ -117,6 +118,21 @@ export function unitToFixedDigits(unit?: string): number {
       return 0;
     default:
       return 2;
+  }
+}
+
+export function unitToExponent(unit: LbtcDenomination): number {
+  switch (unit) {
+    case 'L-BTC':
+      return 0;
+    case 'L-mBTC':
+      return 3;
+    case 'L-bits':
+      return 6;
+    case 'L-sats':
+      return 8;
+    default:
+      return 0;
   }
 }
 

--- a/src/utils/input.ts
+++ b/src/utils/input.ts
@@ -1,23 +1,26 @@
 import type { Dispatch } from 'react';
 
-const MAX_DECIMAL_DIGITS = 8;
+import type { LbtcDenomination } from './constants';
+import { unitToFixedDigits } from './helpers';
 
 /**
  * Sanitize input amount
  * @param eventDetailValue string
  * @param setAmount Dispatch<string>
+ * @param unit
  * @returns sanitizedValue string
  */
 export function sanitizeInputAmount(
   eventDetailValue: string,
   setAmount: Dispatch<string>,
+  unit: LbtcDenomination = 'L-BTC',
 ): string {
   // If value is one of those cases, provoke re-rendering with sanitized value
   if (
     // First comma is always replaced by dot. Reset if user types a second comma
     (eventDetailValue.includes('.') && eventDetailValue.includes(',')) ||
-    // No more than MAX_DECIMAL_DIGITS digits
-    eventDetailValue.split(/[,.]/, 2)[1]?.length > MAX_DECIMAL_DIGITS ||
+    // No more than max decimal digits for respective unit
+    eventDetailValue.split(/[,.]/, 2)[1]?.length > unitToFixedDigits(unit) ||
     // If not numbers or dot
     /[^0-9.]/.test(eventDetailValue) ||
     // No more than one dot
@@ -37,9 +40,9 @@ export function sanitizeInputAmount(
   if ((sanitizedValue.match(/\./g) || []).length > 1) {
     sanitizedValue = sanitizedValue.replace(/\.$/, '');
   }
-  // No more than MAX_DECIMAL_DIGITS decimal digits
-  if (eventDetailValue.split(/[,.]/, 2)[1]?.length > MAX_DECIMAL_DIGITS) {
-    sanitizedValue = Number(eventDetailValue).toFixed(MAX_DECIMAL_DIGITS);
+  // No more than max decimal digits for respective unit
+  if (eventDetailValue.split(/[,.]/, 2)[1]?.length > unitToFixedDigits(unit)) {
+    sanitizedValue = Number(eventDetailValue).toFixed(unitToFixedDigits(unit));
   }
   return sanitizedValue === '' ? '0' : sanitizedValue;
 }

--- a/src/utils/tdex.ts
+++ b/src/utils/tdex.ts
@@ -9,6 +9,7 @@ import type {
   TDEXProvider,
 } from '../redux/actionTypes/tdexActionTypes';
 
+import type { LbtcDenomination } from './constants';
 import { getMainAsset } from './constants';
 import { InvalidTradeTypeError, MakeTradeError } from './errors';
 import { isLbtc, toSatoshi } from './helpers';
@@ -29,7 +30,7 @@ export interface AssetWithTicker {
 export async function bestPrice(
   known: { amount: string; asset: string; precision: number },
   trades: TDEXTrade[],
-  lbtcUnit: string,
+  lbtcUnit: LbtcDenomination,
   onError: (e: string) => void,
 ): Promise<{ amount: number; asset: string; trade: TDEXTrade }> {
   if (trades.length === 0) throw new Error('trades array should not be empty');
@@ -88,7 +89,7 @@ export async function bestBalance(trades: TDEXTrade[]): Promise<TDEXTrade> {
 export async function calculatePrice(
   known: { amount: string; asset: string; precision: number },
   trade: TDEXTrade,
-  lbtcUnit: string,
+  lbtcUnit: LbtcDenomination,
 ): Promise<{ amount: number; asset: string }> {
   if (Number(known.amount) <= 0) {
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,9 +1849,9 @@
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
 "@nodelib/fs.walk@^1.2.3":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz#94c23db18ee4653e129abd26fb06f870ac9e1ee2"
-  integrity sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
@@ -2274,9 +2274,9 @@
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/node@*", "@types/node@>=12.12.47":
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.1.tgz#70cedfda26af7a2ca073fdcc9beb2fff4aa693f8"
-  integrity sha512-hBOx4SUlEPKwRi6PrXuTGw1z6lz0fjsibcWCM378YxsSu/6+C30L6CR49zIBKHiwNWCYIcOLjg4OHKZaFeLAug==
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.3.0.tgz#1836664e4fad13b51b07eb6e882a53925e6543c4"
+  integrity sha512-OydMCocGMGqw/1BnWbhtK+AtwyWTOigtrQlRe57OQmTNcI3HKlVI5FGlh+c4mSqInMPLynFrTlYjfajPu9O/eQ==
 
 "@types/node@10.12.18":
   version "10.12.18"
@@ -2331,9 +2331,9 @@
     "@types/react" "*"
 
 "@types/react-redux@^7.1.16":
-  version "7.1.17"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.17.tgz#b9ccd01624c2a282b7af3762411cbf8945712438"
-  integrity sha512-vdMbWV4tKltQVPCYOYknqb6M9PP8i82ZAV17q60UTYs/MYafplHNgBVPuKVkTN8LMPlXRw7Fs8Y5BxBIRPxz+g==
+  version "7.1.18"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.18.tgz#2bf8fd56ebaae679a90ebffe48ff73717c438e04"
+  integrity sha512-9iwAsPyJ9DLTRH+OFeIrm9cAbIj1i2ANL3sKQFATqnPWRbg+jEFXyZOKHiQK/N86pNRXbb4HRxAxo0SIX1XwzQ==
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.0"
     "@types/react" "*"
@@ -2755,9 +2755,9 @@ acorn-globals@^6.0.0:
     acorn-walk "^7.1.1"
 
 acorn-jsx@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
-  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn-walk@^7.1.1:
   version "7.2.0"
@@ -5262,9 +5262,9 @@ ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.723:
-  version "1.3.770"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.770.tgz#a9e705a73315f4900880622b3ab76cf1d7221b77"
-  integrity sha512-Kyh8DGK1KfEZuYKIHvuOmrKotsKZQ+qBkDIWHciE3QoFkxXB1KzPP+tfLilSHAfxTON0yYMnFCWkQtUOR7g6KQ==
+  version "1.3.771"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.771.tgz#c4aa601e6420e11926095f75fe803956a1b4bd81"
+  integrity sha512-zHMomTqkpnAD9W5rhXE1aiU3ogGFrqWzdvM4C6222SREiqsWQb2w0S7P2Ii44qCaGimmAP1z+OydllM438uJyA==
 
 elementtree@^0.1.7:
   version "0.1.7"
@@ -5980,9 +5980,9 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.1.1:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.6.tgz#434dd9529845176ea049acc9343e8282765c6e1a"
-  integrity sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
+  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -6001,9 +6001,9 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fast-safe-stringify@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
-  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz#dc2af48c46cf712b683e849b2bbd446b32de936f"
+  integrity sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==
 
 fastq@^1.6.0:
   version "1.11.1"


### PR DESCRIPTION
Cannot input more than max decimal digits for respective unit.
If input already has max decimal digits and user input between 6 and 9, the value is rounded above.
Introduce new `LbtcDenomination` type instead of using `string`. 
It fixes #357 

Please review @tiero 