### PR TITLE
[Exchange] Fix flipping assets

### DIFF
--- a/cypress/integration/main.spec.ts
+++ b/cypress/integration/main.spec.ts
@@ -30,7 +30,7 @@ describe('trade', () => {
     cy.launchWallet();
     cy.get('[data-cy=tab-exchange]').click();
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000);
+    cy.wait(3000);
     cy.get('[data-cy=exchange-send-input]').children().type('1');
     cy.get('[data-cy=exchange-confirm-btn]').contains('CONFIRM').click();
     cy.get('[data-cy=description-p]').should(

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -128,23 +128,23 @@ const Exchange: React.FC<ExchangeProps> = ({
   useEffect(() => {
     if (markets.length === 0 || !assetSent || !assetReceived) return;
     setTrades(allTrades(markets, assetSent.asset, assetReceived.asset));
-  }, [assetSent, assetReceived, markets]);
+  }, [assetSent?.asset, assetReceived?.asset, markets]);
 
   useEffect(() => {
-    if (!assetSent || hasBeenSwapped) return;
+    if (!assetSent) return;
     const sentTradables = getTradablesAssets(markets, assetSent.asset);
     // TODO: Add opposite asset and remove current
     setTradableAssetsForAssetReceived(sentTradables);
     setAssetReceived(sentTradables[0]);
-  }, [assetSent, markets]);
+  }, [assetSent?.asset, markets]);
 
   useEffect(() => {
-    if (!assetReceived || hasBeenSwapped) return undefined;
+    if (!assetReceived) return undefined;
     const receivedTradables = getTradablesAssets(markets, assetReceived.asset);
     // TODO: Add opposite asset and remove current
     setTradableAssetsForAssetSent(receivedTradables);
     return () => setAssetReceived(undefined);
-  }, [assetReceived, markets]);
+  }, [assetReceived?.asset, markets]);
 
   const checkAvailableAmountSent = () => {
     if (!trade || !sentAmount || !assetSent) return;
@@ -270,6 +270,14 @@ const Exchange: React.FC<ExchangeProps> = ({
     }
   };
 
+  const swapAssetsAndAmounts = () => {
+    setHasBeenSwapped(true);
+    setAssetSent(assetReceived);
+    setAssetReceived(assetSent);
+    setSentAmount(receivedAmount);
+    setReceivedAmount(sentAmount);
+  };
+
   return (
     <IonPage id="exchange-page">
       <Loader showLoading={isLoading} delay={0} />
@@ -338,18 +346,7 @@ const Exchange: React.FC<ExchangeProps> = ({
               isLoading={isLoading}
             />
 
-            <div
-              className="exchange-divider"
-              onClick={() => {
-                setHasBeenSwapped(true);
-                setAssetSent(assetReceived);
-                setAssetReceived(assetSent);
-                setSentAmount(receivedAmount);
-                setReceivedAmount(sentAmount);
-                setTradableAssetsForAssetSent(tradableAssetsForAssetReceived);
-                setTradableAssetsForAssetReceived(tradableAssetsForAssetSent);
-              }}
-            >
+            <div className="exchange-divider" onClick={swapAssetsAndAmounts}>
               <img src={swap} alt="swap" />
             </div>
 


### PR DESCRIPTION
Fix flipping assets.
Exchange useEffect cleanup functions are triggered when swapping. Current bug was due to the fact that `assetReceived` was not set again after flipping.

Please review @tiero  