### PR TITLE
Fix Withdrawal screen when wallet has no funds

### DIFF
--- a/src/components/WithdrawRow/index.tsx
+++ b/src/components/WithdrawRow/index.tsx
@@ -3,8 +3,6 @@ import {
   IonIcon,
   IonInput,
   IonText,
-  useIonViewDidEnter,
-  useIonViewDidLeave,
 } from '@ionic/react';
 import classNames from 'classnames';
 import Decimal from 'decimal.js';
@@ -56,14 +54,14 @@ const WithdrawRow: React.FC<WithdrawRowInterface> = ({
   const [fiat, setFiat] = useState<string>('0.00');
   const dispatch = useDispatch();
 
-  useIonViewDidEnter(() => {
+  useEffect(() => {
     setAccessoryBar(true).catch(console.error);
-  });
-
-  useIonViewDidLeave(() => {
-    setAccessoryBar(false).catch(console.error);
-    reset();
-  });
+    dispatch(updatePrices());
+    return () => {
+      reset();
+      setAccessoryBar(false).catch(console.error);
+    };
+  }, []);
 
   useEffect(() => {
     setResidualBalance(
@@ -75,10 +73,6 @@ const WithdrawRow: React.FC<WithdrawRowInterface> = ({
       ),
     );
   }, [lbtcUnit, balance.amount]);
-
-  useEffect(() => {
-    dispatch(updatePrices());
-  }, []);
 
   const reset = () => {
     setResidualBalance(
@@ -148,7 +142,7 @@ const WithdrawRow: React.FC<WithdrawRowInterface> = ({
               inputmode="decimal"
               onIonChange={handleInputChange}
               onKeyDown={onPressEnterKeyCloseKeyboard}
-              pattern="^[0-9]+(([.,][0-9]+)?)$"
+              pattern="^[0-9]*[.,]?[0-9]*$"
               placeholder="0"
               type="tel"
               value={amount}

--- a/src/components/WithdrawRow/index.tsx
+++ b/src/components/WithdrawRow/index.tsx
@@ -1,9 +1,5 @@
 import type { InputChangeEventDetail } from '@ionic/core';
-import {
-  IonIcon,
-  IonInput,
-  IonText,
-} from '@ionic/react';
+import { IonIcon, IonInput, IonText } from '@ionic/react';
 import classNames from 'classnames';
 import Decimal from 'decimal.js';
 import { chevronDownOutline } from 'ionicons/icons';

--- a/src/pages/Deposit/index.tsx
+++ b/src/pages/Deposit/index.tsx
@@ -5,7 +5,6 @@ import type { RouteComponentProps } from 'react-router';
 
 import Header from '../../components/Header';
 import { CurrencyIcon } from '../../components/icons';
-import { network } from '../../redux/config';
 import './style.scss';
 import { routerLinks } from '../../routes';
 import { BTC_ASSET, MAIN_ASSETS } from '../../utils/constants';
@@ -15,8 +14,6 @@ const Deposit: React.FC<RouteComponentProps> = ({ history }) => {
     return [BTC_ASSET]
       .concat(MAIN_ASSETS)
       .map((asset, i) => {
-        if (asset.ticker === 'L-BTC' && network.chain !== asset?.chain)
-          return null;
         return (
           <button
             className="deposit-grid-item ion-justify-content-center ion-align-items-center"

--- a/src/pages/Operations/index.tsx
+++ b/src/pages/Operations/index.tsx
@@ -314,7 +314,7 @@ const Operations: React.FC<OperationsProps> = ({
               <IonList>
                 <IonListHeader>Transactions</IonListHeader>
                 <WatchersLoader />
-                {balance &&
+                {balance && transactionsToDisplay.length ? (
                   transactionsToDisplay
                     .concat(btcTxs)
                     .sort(compareTxDisplayInterfaceByDate)
@@ -425,7 +425,10 @@ const Operations: React.FC<OperationsProps> = ({
                           </div>
                         </IonItem>
                       );
-                    })}
+                    })
+                ) : (
+                  <p>You don't have any transactions yet</p>
+                )}
               </IonList>
             </IonCol>
           </IonRow>

--- a/src/redux/reducers/walletReducer.ts
+++ b/src/redux/reducers/walletReducer.ts
@@ -11,6 +11,7 @@ import {
   defaultPrecision,
   LBTC_COINGECKOID,
   LBTC_TICKER,
+  LBTC_ASSET,
   getMainAsset,
 } from '../../utils/constants';
 import {
@@ -166,6 +167,17 @@ export const balancesSelector = createSelector(
         coinGeckoID: getMainAsset(asset)?.coinGeckoID,
         precision: assets[asset]?.precision ?? defaultPrecision,
         name: assets[asset]?.name,
+      });
+    }
+    // If no balance, add LBTC with amount zero
+    if (!balances.length) {
+      balances.push({
+        asset: LBTC_ASSET.assetHash,
+        amount: 0,
+        ticker: LBTC_TICKER,
+        coinGeckoID: LBTC_ASSET.coinGeckoID,
+        precision: LBTC_ASSET.precision,
+        name: LBTC_ASSET.name,
       });
     }
     return balances;


### PR DESCRIPTION
When wallet doesn't have funds, withdrawal input was not displayed. Now it is displayed, with available balance to withdraw equals to zero.

Please review @tiero 