### PR TITLE
Refactor Trade History rows

### DIFF
--- a/src/pages/Operations/index.tsx
+++ b/src/pages/Operations/index.tsx
@@ -36,11 +36,6 @@ import type { Transfer, TxDisplayInterface } from '../../utils/types';
 import { TxStatusEnum, TxTypeEnum } from '../../utils/types';
 import './style.scss';
 
-const statusText = {
-  confirmed: 'confirmed',
-  pending: 'pending',
-};
-
 interface OperationsProps extends RouteComponentProps {
   balances: BalanceInterface[];
   prices: Record<string, number>;
@@ -123,16 +118,17 @@ const Operations: React.FC<OperationsProps> = ({
   };
 
   const renderStatusText: any = (status: string) => {
+    const capitalized = (status[0].toUpperCase() + status.slice(1)) as keyof typeof TxStatusEnum;
     switch (status) {
       case TxStatusEnum.Confirmed:
         return (
           <span className="status-text confirmed">
             <IonIcon icon={checkmarkSharp} />
-            <span className="ml-2">{statusText[status]}</span>
+            <span className="ml-2">{TxStatusEnum[capitalized]}</span>
           </span>
         );
       case TxStatusEnum.Pending:
-        return <span className="status-text pending">{statusText[status]}</span>;
+        return <span className="status-text pending">{TxStatusEnum[capitalized]}</span>;
       default:
         return <span className="status-text pending" />;
     }
@@ -309,7 +305,7 @@ const Operations: React.FC<OperationsProps> = ({
                         </IonRow>
                         <div className="extra-infos">
                           {TxTypeEnum[tx.type] !== 'DepositBtc' && (
-                            <IonRow className="mt-5">
+                            <IonRow className="mt-3">
                               <IonCol className="pl-5" size="6" offset="1">
                                 {`Fee: ${fromSatoshi(tx.fee.toString(), 8).toFixed(8)} ${LBTC_TICKER}`}
                               </IonCol>
@@ -318,7 +314,7 @@ const Operations: React.FC<OperationsProps> = ({
                               </IonCol>
                             </IonRow>
                           )}
-                          <IonRow className="mt-5">
+                          <IonRow className="mt-3">
                             <IonCol className="pl-5" size="11" offset="1">
                               TxID: {tx.txId}
                             </IonCol>
@@ -333,7 +329,7 @@ const Operations: React.FC<OperationsProps> = ({
                                         ? getConfirmationCount(tx.blockHeight) < 101
                                         : true,
                                     },
-                                    'pl-5 mt-5'
+                                    'pl-5 mt-3'
                                   )}
                                   size="11"
                                   offset="1"

--- a/src/pages/Operations/style.scss
+++ b/src/pages/Operations/style.scss
@@ -61,15 +61,6 @@
   }
   
   .operation-item {
-    .pl-5 {
-      padding-left: 5px;
-    }
-    .mt-5 {
-      margin-top: 5px;
-    }
-    .ml-2 {
-      margin-left: 2px;
-    }
     &::part(native) {
       width: 100%;
       flex-direction: column;

--- a/src/pages/TradeHistory/style.scss
+++ b/src/pages/TradeHistory/style.scss
@@ -1,75 +1,54 @@
 #trade-history {
-	.status {
-		font-family: var(--ion-font-sub-heading);
-		font-size: var(--ion-font-size-sub);
-	}
-	
-	.sub-info {
-		font-family: var(--ion-font-sub-heading);
-		font-size: var(--ion-font-size-sub);
-	}
-	
-	.info-row {
-		align-items: baseline;
-	}
-	
-	ion-item.tx-item {
-		font-size: var(--ion-font-size-sub);
-		--padding-top: 0;
-		--padding-bottom: 0;
-		--padding-end: 0;
-		--padding-start: 0;
-	}
-	
-	.item-main-info {
-		align-items: end;
-		
-		.swap-images {
-			flex: 10px;
-		}
-		
-		.item-start {
-			flex: 40%;
-			margin-right: 3px;
-		}
-		
-		.item-end {
-			flex: 40%;
-			
-			.amount {
-				.main-row {
-					font-size: var(--ion-font-size-main);
-				}
-				
-				.main-row.accent {
-					font-size: var(--ion-font-size-sub);
-				}
-			}
-		}
-	}
-	
-	
-	.list-item {
-		&.pending {
-			background-color: rgba(255, 220, 0, 0.15);
-		}
-		
-		&.open {
-			background-color: #444;
-		}
-		
-		.swap-images {
-			margin-right: 4px;
-			img {
-				width: 16px;
-				height: 16px;
-			}
-			
-			img:nth-child(2) {
-				position: absolute;
-				left: 6px;
-				top: 0;
-			}
-		}
-	}
+  .transaction-item {
+    &::part(native) {
+      width: 100%;
+      flex-direction: column;
+      flex: 1;
+    }
+    ion-row {
+      align-items: end;
+      width: 100%;
+    }
+    .icon {
+      padding-right: 10px;
+      display: flex;
+      img {
+        height: 4.5vw;
+        width: 4.5vw;
+        &:nth-child(2) {
+          transform: translateX(-2.5vw);
+        }
+      }
+    }
+    .asset {
+      font-family: var(--ion-font-main);
+      font-size: var(--ion-font-size-main);
+    }
+    .time {
+      font-family: var(--ion-font-sub-heading);
+      font-size: var(--ion-font-size-sub-xs);
+      color: var(--ion-color-tertiary);
+      line-height: 18px;
+    }
+    .trade-amount {
+      font-family: var(--ion-font-sub-heading);
+      font-size: var(--ion-font-size-sub-l);
+      span.ticker {
+        font-family: var(--ion-font-sub);
+        font-size: var(--ion-font-size-sub-s);
+        margin-left: 1vw;
+	      align-items: center;
+	      display: inline-flex;
+      }
+    }
+    .extra-infos {
+      font-family: var(--ion-font-sub-heading);
+      font-size: var(--ion-font-size-sub-xs);
+      color: var(--ion-color-tertiary);
+      line-break: anywhere;
+      .confirmations-pending {
+        color: rgba(var(--ion-color-warning-rgb), 0.6);
+      }
+    }
+  }
 }

--- a/src/theme/global.scss
+++ b/src/theme/global.scss
@@ -36,3 +36,13 @@ span {
 .bg-transparent {
   --ion-background-color: transparent !important;
 }
+
+.pl-5 {
+  padding-left: 5px;
+}
+.mt-3 {
+  margin-top: 3px;
+}
+.ml-2 {
+  margin-left: 2px;
+}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -189,6 +189,12 @@ export function tickerFromAssetHash(assetHash?: string): string {
   return assetHash.slice(0, 4).toUpperCase();
 }
 
+export function precisionFromAssetHash(assetHash?: string): number | undefined {
+  if (!assetHash) return 8;
+  const mainAsset = getMainAsset(assetHash);
+  if (mainAsset) return mainAsset.precision;
+}
+
 export function nameFromAssetHash(assetHash?: string): string | undefined {
   if (!assetHash) return '';
   const mainAsset = getMainAsset(assetHash);


### PR DESCRIPTION
Refactor Trade History rows to be prettier.
Note: We don't display the fiat value.

Please review @tiero 

Before
<img width="337" alt="Screenshot 2021-08-13 at 18 33 52" src="https://user-images.githubusercontent.com/4022128/129404797-7a62bd9c-a578-4360-bcd9-2eb318d7619a.png">

After
<img width="337" alt="Screenshot 2021-08-13 at 19 43 36" src="https://user-images.githubusercontent.com/4022128/129404799-f328047c-6e53-4bd0-bac9-9efaea0f05b7.png">
