### PR TITLE
Fix input scroll on Android

### DIFF
--- a/src/theme/components/ionic/index.scss
+++ b/src/theme/components/ionic/index.scss
@@ -1,6 +1,7 @@
 @import './ion-back-button.scss';
 @import './ion-button.scss';
 @import './ion-item.scss';
+@import './ion-input.scss';
 @import './ion-list-header.scss';
 @import './ion-loading.scss';
 @import './ion-modal.scss';

--- a/src/theme/components/ionic/ion-input.scss
+++ b/src/theme/components/ionic/ion-input.scss
@@ -1,0 +1,3 @@
+ion-input {
+	overflow-x: scroll !important;
+}


### PR DESCRIPTION
Fix input scroll on Android.
Can't find a solution for iOS. Issue #411 has been opened.

Please review @tiero 