### PR TITLE
Remove unused push notification block

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -57,18 +57,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       NotificationCenter.default.post(name: .capacitorStatusBarTapped, object: nil)
     }
   }
-
-  #if USE_PUSH
-
-  func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-    NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
-  }
-
-  func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-    NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
-  }
-
-#endif
-
 }
 


### PR DESCRIPTION
Following Capacitor 3 recommendation, if not using push notifications we can remove the whole block.
https://capacitorjs.com/docs/updating/3-0#remove-usepush-compilation-condition

Please review @tiero 