### PR TITLE
Validate provider url

### DIFF
--- a/src/pages/LiquidityProvider/index.tsx
+++ b/src/pages/LiquidityProvider/index.tsx
@@ -173,7 +173,10 @@ const LiquidityProviders: React.FC<LiquidityProvidersProps> = ({ providers, netw
                     mainDisabled={isNewProviderInvalid()}
                     mainOnClick={() => {
                       const url = new URL(newProviderEndpoint);
-                      if (!newProviderEndpoint.includes('.onion') && url.protocol === 'https:') {
+                      if (
+                        newProviderEndpoint.includes('.onion') ||
+                        (!newProviderEndpoint.includes('.onion') && url.protocol === 'https:')
+                      ) {
                         setNewProvider(false);
                         dispatch(
                           addProvider({

--- a/src/pages/LiquidityProvider/index.tsx
+++ b/src/pages/LiquidityProvider/index.tsx
@@ -172,9 +172,8 @@ const LiquidityProviders: React.FC<LiquidityProvidersProps> = ({ providers, netw
                     subTitle="CANCEL"
                     mainDisabled={isNewProviderInvalid()}
                     mainOnClick={() => {
-                      if (!newProviderEndpoint.startsWith('http')) {
-                        dispatch(addErrorToast(InvalidUrl));
-                      } else {
+                      const url = new URL(newProviderEndpoint);
+                      if (!newProviderEndpoint.includes('.onion') && url.protocol === 'https:') {
                         setNewProvider(false);
                         dispatch(
                           addProvider({
@@ -182,6 +181,8 @@ const LiquidityProviders: React.FC<LiquidityProvidersProps> = ({ providers, netw
                             name: newProviderName.trim(),
                           })
                         );
+                      } else {
+                        dispatch(addErrorToast(InvalidUrl));
                       }
                     }}
                     subOnClick={() => setNewProvider(false)}


### PR DESCRIPTION
If it's not an onion url, then it should be https.

Note: 
If onion url doesn't have http(s) protocol, URL api fails to decode properly.
let url = new URL('onlybestyqgaaloz2azrefzu6kkrtakrh324ana2fqfrzpves2rgsqyd.onion:9945');
url.protocol === "onlybestyqgaaloz2azrefzu6kkrtakrh324ana2fqfrzpves2rgsqyd.onion:"

Please review @tiero