### PR TITLE
Fix identity check

### DIFF
--- a/src/redux/reducers/walletReducer.ts
+++ b/src/redux/reducers/walletReducer.ts
@@ -208,7 +208,7 @@ export function isMnemonic(identity: any): identity is Mnemonic {
 }
 
 export function isMasterPublicKey(identity: any): identity is MasterPublicKey {
-  return identity?.masterPublicKeyNode !== undefined;
+  return identity?.mnemonic === undefined;
 }
 
 export default walletReducer;


### PR DESCRIPTION
Since `masterPublicKeyNode` is also present on Mnemonic identity the restoration was buggy.