### PR TITLE
Refactor sagas, monitor market fetching

### DIFF
--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -7,13 +7,21 @@ interface LoaderProps {
   delay?: number;
   message?: string;
   showLoading: boolean;
+  backdropDismiss?: boolean;
 }
 
-const Loader: React.FC<LoaderProps> = ({ delay, message, showLoading }) => {
+const Loader: React.FC<LoaderProps> = ({ backdropDismiss = false, delay, message, showLoading }) => {
   return useDelayedRender(
     delay ?? 500,
     showLoading
-  )(() => <IonLoading isOpen={showLoading} message={message || 'Please wait...'} spinner="lines" />);
+  )(() => (
+    <IonLoading
+      isOpen={showLoading}
+      message={message || 'Please wait...'}
+      spinner="lines"
+      backdropDismiss={backdropDismiss}
+    />
+  ));
 };
 
 export default Loader;

--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -4,13 +4,22 @@ import React from 'react';
 import { useDelayedRender } from '../../hooks/useDelayedRender';
 
 interface LoaderProps {
+  showLoading: boolean;
   delay?: number;
   message?: string;
-  showLoading: boolean;
   backdropDismiss?: boolean;
+  onDidDismiss?: () => void;
+  duration?: number;
 }
 
-const Loader: React.FC<LoaderProps> = ({ backdropDismiss = false, delay, message, showLoading }) => {
+const Loader: React.FC<LoaderProps> = ({
+  backdropDismiss = false,
+  onDidDismiss,
+  duration = 0,
+  delay,
+  message,
+  showLoading,
+}) => {
   return useDelayedRender(
     delay ?? 500,
     showLoading
@@ -20,6 +29,8 @@ const Loader: React.FC<LoaderProps> = ({ backdropDismiss = false, delay, message
       message={message || 'Please wait...'}
       spinner="lines"
       backdropDismiss={backdropDismiss}
+      onDidDismiss={onDidDismiss}
+      duration={duration}
     />
   ));
 };

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -224,7 +224,6 @@ const Exchange: React.FC<ExchangeProps> = ({
       } catch (_) {
         throw IncorrectPINError;
       }
-      if (!bestTrade) return;
       const txid = await makeTrade(
         bestTrade,
         {
@@ -253,13 +252,11 @@ const Exchange: React.FC<ExchangeProps> = ({
           amount: receivedAmount?.toString() || '??',
         },
       };
-      setIsBusyMakingTrade(false);
       history.replace(`/tradesummary/${txid}`, { preview });
     } catch (e) {
       console.error(e);
       dispatch(unlockUtxos());
       setIsWrongPin(true);
-      setIsBusyMakingTrade(false);
       setTimeout(() => {
         setIsWrongPin(null);
         setNeedReset(true);
@@ -267,6 +264,8 @@ const Exchange: React.FC<ExchangeProps> = ({
       if (e instanceof AppError) {
         dispatch(addErrorToast(e));
       }
+    } finally {
+      setIsBusyMakingTrade(false);
     }
   };
 

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -122,7 +122,7 @@ const Exchange: React.FC<ExchangeProps> = ({
           handler: () => {
             dismissNoProvidersAvailableAlert()
               .then(() => {
-                history.push('/wallet');
+                history.replace('/wallet');
               })
               .catch(console.error);
           },

--- a/src/pages/LiquidityProvider/index.tsx
+++ b/src/pages/LiquidityProvider/index.tsx
@@ -27,7 +27,7 @@ import Header from '../../components/Header';
 import type { TDEXProvider } from '../../redux/actionTypes/tdexActionTypes';
 import './style.scss';
 import {
-  addProvider,
+  addProviders,
   clearMarkets,
   clearProviders,
   deleteProvider,
@@ -57,8 +57,7 @@ export const refreshProviders = async (
       if (newProviders.length) {
         dispatch(clearProviders());
         dispatch(clearMarkets());
-        const actions = providersFromRegistry.map(addProvider);
-        actions.forEach(dispatch);
+        dispatch(addProviders(providersFromRegistry));
       }
       dispatch(addSuccessToast(`${newProviders.length} new providers from TDEX registry!`));
     } catch {
@@ -67,11 +66,11 @@ export const refreshProviders = async (
   } else if (network === 'testnet') {
     dispatch(clearProviders());
     dispatch(clearMarkets());
-    dispatch(addProvider({ endpoint: defaultProviderEndpoints.testnet, name: 'Default provider' }));
+    dispatch(addProviders([{ endpoint: defaultProviderEndpoints.testnet, name: 'Default provider' }]));
   } else {
     dispatch(clearProviders());
     dispatch(clearMarkets());
-    dispatch(addProvider({ endpoint: defaultProviderEndpoints.regtest, name: 'Default provider' }));
+    dispatch(addProviders([{ endpoint: defaultProviderEndpoints.regtest, name: 'Default provider' }]));
   }
 };
 
@@ -179,10 +178,12 @@ const LiquidityProviders: React.FC<LiquidityProvidersProps> = ({ providers, netw
                       ) {
                         setNewProvider(false);
                         dispatch(
-                          addProvider({
-                            endpoint: newProviderEndpoint.trim(),
-                            name: newProviderName.trim(),
-                          })
+                          addProviders([
+                            {
+                              endpoint: newProviderEndpoint.trim(),
+                              name: newProviderName.trim(),
+                            },
+                          ])
                         );
                       } else {
                         dispatch(addErrorToast(InvalidUrl));

--- a/src/pages/Wallet/index.tsx
+++ b/src/pages/Wallet/index.tsx
@@ -33,6 +33,7 @@ interface WalletProps extends RouteComponentProps {
   balances: BalanceInterface[];
   currency: string;
   isFetchingUtxos: boolean;
+  isFetchingMarkets: boolean;
   lbtcUnit: LbtcDenomination;
   network: NetworkString;
   prices: Record<string, number>;
@@ -44,6 +45,7 @@ const Wallet: React.FC<WalletProps> = ({
   balances,
   currency,
   isFetchingUtxos,
+  isFetchingMarkets,
   history,
   lbtcUnit,
   network,
@@ -121,7 +123,7 @@ const Wallet: React.FC<WalletProps> = ({
             hasCloseButton={true}
             hasBackButton={false}
             isTitleLarge={true}
-            customRightButton={isFetchingUtxos ? <IonSpinner name="lines-small" /> : <></>}
+            customRightButton={isFetchingUtxos || isFetchingMarkets ? <IonSpinner name="lines-small" /> : <></>}
           />
           <IonRow className="ion-margin-vertical ion-justify-content-center">
             <CircleTotalBalance

--- a/src/redux/actions/appActions.ts
+++ b/src/redux/actions/appActions.ts
@@ -10,6 +10,7 @@ export const SET_SIGNED_UP = 'SET_SIGNED_UP';
 export const SIGN_IN = 'SIGN_IN';
 export const UPDATE = 'UPDATE';
 export const SET_IS_FETCHING_UTXOS = 'SET_IS_FETCHING_UTXOS';
+export const SET_IS_FETCHING_MARKETS = 'SET_IS_FETCHING_MARKETS';
 export const SET_IS_BACKUP_DONE = 'SET_IS_BACKUP_DONE';
 
 export const setIsBackupDone = (done: boolean): ActionType => {
@@ -29,6 +30,13 @@ export const setIsFetchingUtxos = (isFetchingUtxos: boolean): ActionType => {
   return {
     type: SET_IS_FETCHING_UTXOS,
     payload: isFetchingUtxos,
+  };
+};
+
+export const setIsFetchingMarkets = (isFetchingMarkets: boolean): ActionType => {
+  return {
+    type: SET_IS_FETCHING_MARKETS,
+    payload: isFetchingMarkets,
   };
 };
 

--- a/src/redux/actions/appActions.ts
+++ b/src/redux/actions/appActions.ts
@@ -33,7 +33,7 @@ export const setIsFetchingUtxos = (isFetchingUtxos: boolean): ActionType => {
   };
 };
 
-export const setIsFetchingMarkets = (isFetchingMarkets: boolean): ActionType => {
+export const setIsFetchingMarkets = (isFetchingMarkets: boolean): ActionType<boolean> => {
   return {
     type: SET_IS_FETCHING_MARKETS,
     payload: isFetchingMarkets,

--- a/src/redux/actions/tdexActions.ts
+++ b/src/redux/actions/tdexActions.ts
@@ -1,7 +1,7 @@
 import type { ActionType } from '../../utils/types';
 import type { TDEXProvider, TDEXMarket } from '../actionTypes/tdexActionTypes';
 
-export const ADD_PROVIDER = 'ADD_PROVIDER_ENDPOINT';
+export const ADD_PROVIDERS = 'ADD_PROVIDERS';
 export const DELETE_PROVIDER = 'DELETE_PROVIDER';
 export const CLEAR_PROVIDERS = 'CLEAR_PROVIDERS';
 export const UPDATE_MARKETS = 'UPDATE_MARKETS';
@@ -25,10 +25,10 @@ export const updateMarkets = (): ActionType => {
   };
 };
 
-export const addProvider = (provider: TDEXProvider): ActionType => {
+export const addProviders = (providers: TDEXProvider[]): ActionType<TDEXProvider[]> => {
   return {
-    type: ADD_PROVIDER,
-    payload: provider,
+    type: ADD_PROVIDERS,
+    payload: providers,
   };
 };
 

--- a/src/redux/actions/walletActions.ts
+++ b/src/redux/actions/walletActions.ts
@@ -1,6 +1,5 @@
 import type { AddressInterface, Mnemonic, Outpoint, UtxoInterface } from 'ldk';
 import { address as addrLDK } from 'ldk';
-import type { AnyAction } from 'redux';
 
 import type { ActionType } from '../../utils/types';
 import { outpointToString } from '../reducers/walletReducer';
@@ -27,11 +26,11 @@ export const watchUtxo = (address: AddressInterface, maxTry = 100): ActionType =
   },
 });
 
-export const unlockUtxos = (): AnyAction => ({
+export const unlockUtxos = (): ActionType => ({
   type: UNLOCK_UTXOS,
 });
 
-export const addAddress = (address: AddressInterface): AnyAction => {
+export const addAddress = (address: AddressInterface): ActionType<{ address: AddressInterface; script: string }> => {
   return {
     type: ADD_ADDRESS,
     payload: {
@@ -47,21 +46,21 @@ export const clearAddresses = (): ActionType => {
   };
 };
 
-export const lockUtxo = (txid: string, vout: number): AnyAction => {
+export const lockUtxo = (txid: string, vout: number): ActionType => {
   return {
     type: LOCK_UTXO,
     payload: outpointToString({ txid, vout }),
   };
 };
 
-export const unlockUtxo = (outpointStr: string): AnyAction => {
+export const unlockUtxo = (outpointStr: string): ActionType => {
   return {
     type: UNLOCK_UTXO,
     payload: outpointStr,
   };
 };
 
-export const setMasterPublicKeysFromMnemonic = (mnemonic: Mnemonic): AnyAction => {
+export const setMasterPublicKeysFromMnemonic = (mnemonic: Mnemonic): ActionType => {
   return {
     type: SET_MASTER_PUBLIC_KEYS_FROM_MNEMONIC,
     payload: mnemonic,

--- a/src/redux/containers/exchangeContainer.tsx
+++ b/src/redux/containers/exchangeContainer.tsx
@@ -12,6 +12,7 @@ const mapStateToProps = (state: RootState) => {
       (b) => b.amount > 0 && getTradablesAssets(state.tdex.markets, b.asset, state.settings.network).length > 0
     ),
     explorerLiquidAPI: state.settings.explorerLiquidAPI,
+    isFetchingMarkets: state.app.isFetchingMarkets,
     lastUsedIndexes: lastUsedIndexesSelector(state),
     lbtcUnit: state.settings.denominationLBTC,
     markets: state.tdex.markets,

--- a/src/redux/containers/walletContainer.tsx
+++ b/src/redux/containers/walletContainer.tsx
@@ -10,6 +10,7 @@ const mapStateToProps = (state: RootState) => {
     balances: balancesSelector(state),
     currency: state.settings.currency.value,
     isFetchingUtxos: state.app.isFetchingUtxos,
+    isFetchingMarkets: state.app.isFetchingMarkets,
     lbtcUnit: state.settings.denominationLBTC,
     network: state.settings.network,
     prices: state.rates.prices,

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -25,10 +25,8 @@ const combinedReducers = combineReducers({
   toasts: toastReducer,
 });
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const rootReducer = (state: any, action: ActionType) => {
+const rootReducer: typeof combinedReducers = (state: any, action: ActionType) => {
   if (action.type === RESET_ALL) {
-    // eslint-disable-next-line no-param-reassign
     state = undefined;
   }
   return combinedReducers(state, action);

--- a/src/redux/reducers/appReducer.ts
+++ b/src/redux/reducers/appReducer.ts
@@ -3,6 +3,7 @@ import {
   INIT_APP_FAIL,
   INIT_APP_SUCCESS,
   SET_IS_BACKUP_DONE,
+  SET_IS_FETCHING_MARKETS,
   SET_IS_FETCHING_UTXOS,
   SET_SIGNED_UP,
 } from '../actions/appActions';
@@ -12,6 +13,7 @@ export interface AppState {
   isSignedUp: boolean;
   backupDone: boolean;
   isFetchingUtxos: boolean;
+  isFetchingMarkets: boolean;
 }
 
 const initialState: AppState = {
@@ -19,6 +21,7 @@ const initialState: AppState = {
   isSignedUp: false,
   backupDone: false,
   isFetchingUtxos: false,
+  isFetchingMarkets: false,
 };
 
 function appReducer(state = initialState, action: ActionType): AppState {
@@ -43,6 +46,11 @@ function appReducer(state = initialState, action: ActionType): AppState {
       return {
         ...state,
         isFetchingUtxos: action.payload,
+      };
+    case SET_IS_FETCHING_MARKETS:
+      return {
+        ...state,
+        isFetchingMarkets: action.payload,
       };
     default:
       return state;

--- a/src/redux/reducers/assetsReducer.ts
+++ b/src/redux/reducers/assetsReducer.ts
@@ -5,7 +5,7 @@ import { MAIN_ASSETS } from '../../utils/constants';
 import type { ActionType } from '../../utils/types';
 import { RESET_ASSETS, SET_ASSET } from '../actions/assetsActions';
 
-type AssetsState = Record<string, AssetConfig>;
+export type AssetsState = Record<string, AssetConfig>;
 
 const assetsReducer = (state: AssetsState = {}, action: ActionType): AssetsState => {
   switch (action.type) {

--- a/src/redux/reducers/tdexReducer.ts
+++ b/src/redux/reducers/tdexReducer.ts
@@ -5,7 +5,7 @@ import { tickerFromAssetHash } from '../../utils/helpers';
 import type { AssetWithTicker } from '../../utils/tdex';
 import type { ActionType } from '../../utils/types';
 import type { TDEXMarket, TDEXProvider } from '../actionTypes/tdexActionTypes';
-import { ADD_MARKETS, ADD_PROVIDER, CLEAR_MARKETS, CLEAR_PROVIDERS, DELETE_PROVIDER } from '../actions/tdexActions';
+import { ADD_MARKETS, ADD_PROVIDERS, CLEAR_MARKETS, CLEAR_PROVIDERS, DELETE_PROVIDER } from '../actions/tdexActions';
 
 export interface TDEXState {
   providers: TDEXProvider[];
@@ -26,13 +26,17 @@ const TDEXReducer = (
       return { ...state, markets: [...state.markets, ...action.payload] };
     case CLEAR_MARKETS:
       return { ...state, markets: [] };
-    case ADD_PROVIDER:
-      return state.providers.find((p) => p.endpoint === action.payload.endpoint) === undefined
-        ? {
-            ...state,
-            providers: [...state.providers, action.payload],
-          }
-        : state;
+    case ADD_PROVIDERS: {
+      const newProviders: TDEXProvider[] = [];
+      action.payload.forEach((p: TDEXProvider) => {
+        const isProviderInState = state.providers.some(({ endpoint }) => endpoint === p.endpoint);
+        if (!isProviderInState) newProviders.push(p);
+      });
+      return {
+        ...state,
+        providers: [...state.providers, ...newProviders],
+      };
+    }
     case DELETE_PROVIDER:
       return {
         ...state,

--- a/src/redux/reducers/walletReducer.ts
+++ b/src/redux/reducers/walletReducer.ts
@@ -48,6 +48,7 @@ export const initialState: WalletState = {
 function walletReducer(state = initialState, action: ActionType): WalletState {
   switch (action.type) {
     case ADD_ADDRESS: {
+      if (Object.keys(state.addresses).includes(action.payload.script)) return state;
       const { isChange, index } = getIndexAndIsChangeFromAddress(action.payload.address);
       return {
         ...state,

--- a/src/redux/sagas/btcSaga.ts
+++ b/src/redux/sagas/btcSaga.ts
@@ -10,7 +10,6 @@ import { masterPubKeyRestorerFromState } from 'tdex-sdk';
 import { NoClaimFoundError, PeginRestorationError, UpdateUtxosError } from '../../utils/errors';
 import { getPeginsFromStorage, setPeginsInStorage } from '../../utils/storage-helper';
 import type { ActionType } from '../../utils/types';
-import { SIGN_IN } from '../actions/appActions';
 import {
   setCurrentBtcBlockHeight,
   setDepositPeginUtxo,
@@ -30,14 +29,14 @@ import { outpointToString } from '../reducers/walletReducer';
 import { getPeginModule } from '../services/btcService';
 import type { RootState, SagaGenerator } from '../types';
 
+export function* restorePegins(): SagaGenerator<void, Pegins> {
+  const pegins = yield call(getPeginsFromStorage);
+  yield put(upsertPegins(pegins));
+}
+
 function* persistPegins() {
   const pegins: Pegins = yield select((state) => state.btc.pegins);
   yield call(setPeginsInStorage, pegins);
-}
-
-function* restorePegins() {
-  const pegins: Pegins = yield call(getPeginsFromStorage);
-  yield put(upsertPegins(pegins));
 }
 
 // Fetch block height continuously every minute
@@ -222,7 +221,6 @@ function* checkIfClaimablePeginUtxo() {
 }
 
 export function* btcWatcherSaga(): SagaGenerator {
-  yield takeLatest(SIGN_IN, restorePegins);
   yield takeLatest(UPDATE_DEPOSIT_PEGIN_UTXOS, function* () {
     yield* updateDepositPeginUtxosState();
     yield* persistPegins();

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -5,7 +5,7 @@ import rootReducer from './reducer';
 
 const sagaMiddleware = createSagaMiddleware();
 const middlewares = applyMiddleware(sagaMiddleware);
-const composeEnhancers = (window && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
+const composeEnhancers = (window && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ maxAge: 100 })) || compose;
 const store = createStore(rootReducer, composeEnhancers(middlewares));
 
 export { store, sagaMiddleware };

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -5,7 +5,7 @@ import rootReducer from './reducer';
 
 const sagaMiddleware = createSagaMiddleware();
 const middlewares = applyMiddleware(sagaMiddleware);
-const composeEnhancers = (window && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ maxAge: 100 })) || compose;
+const composeEnhancers = (window && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
 const store = createStore(rootReducer, composeEnhancers(middlewares));
 
 export { store, sagaMiddleware };

--- a/src/theme/components/ionic/ion-alert.scss
+++ b/src/theme/components/ionic/ion-alert.scss
@@ -1,13 +1,16 @@
 [aria-checked=true].sc-ion-alert-ios .alert-radio-label.sc-ion-alert-ios {
-	color: var(--ion-color-secondary, #3880ff);
+  color: var(--ion-color-secondary, #3880ff);
 }
+
 [aria-checked=true].sc-ion-alert-ios .alert-radio-inner.sc-ion-alert-ios {
-	border-color: var(--ion-color-secondary, #3880ff);
+  border-color: var(--ion-color-secondary, #3880ff);
 }
+
 .alert-button.sc-ion-alert-ios {
-	border-top: 0.55px solid rgba(var(--ion-color-tertiary-rgb), 0.4);
-	border-right: 0.55px solid rgba(var(--ion-color-tertiary-rgb), 0.4);
+  border-top: 0.55px solid rgba(var(--ion-color-tertiary-rgb), 0.4);
+  border-right: 0.55px solid rgba(var(--ion-color-tertiary-rgb), 0.4);
 }
+
 .alert-radio-group.sc-ion-alert-ios, .alert-checkbox-group.sc-ion-alert-ios {
-	border-top: 0.55px solid rgba(var(--ion-color-tertiary-rgb), 0.4);
+  border-top: 0.55px solid rgba(var(--ion-color-tertiary-rgb), 0.4);
 }

--- a/test/saga/wallet.saga.spec.ts
+++ b/test/saga/wallet.saga.spec.ts
@@ -2,7 +2,7 @@
 
 import type { AddressInterface, UtxoInterface } from 'ldk';
 import { fetchAndUnblindUtxos } from 'ldk';
-import type { CallEffect, PutEffect } from 'redux-saga/effects';
+import type { PutEffect, StrictEffect } from 'redux-saga/effects';
 
 import { SET_UTXO, DELETE_UTXO, RESET_UTXOS } from '../../src/redux/actions/walletActions';
 import { outpointToString } from '../../src/redux/reducers/walletReducer';
@@ -26,8 +26,8 @@ describe('wallet saga', () => {
     test('should discover and add utxo', async () => {
       const gen = fetchAndUpdateUtxos([addr], {}, APIURL);
       // simulate the first call
-      const callEffect = gen.next().value as CallEffect<IteratorResult<UtxoInterface, number>>;
-      const result = await callEffect.payload.fn();
+      const callEffect = gen.next().value as StrictEffect<IteratorResult<UtxoInterface, number>>;
+      const result = await callEffect?.payload.fn();
       const put = gen.next(result).value as PutEffect<ActionType>;
 
       expect(put.payload.action.type).toEqual(SET_UTXO);
@@ -39,7 +39,7 @@ describe('wallet saga', () => {
       const gen = fetchAndUpdateUtxos([addr], current, APIURL);
 
       let next = gen.next();
-      while (next.value.type !== 'PUT' || next.value.payload.action.type !== 'DELETE_UTXO') {
+      while (next.value?.type !== 'PUT' || next.value?.payload.action.type !== 'DELETE_UTXO') {
         if (next.done) break;
         if (next.value.type === 'CALL') {
           const result = await next.value.payload.fn();
@@ -50,8 +50,8 @@ describe('wallet saga', () => {
         next = gen.next();
       }
 
-      expect(next.value.payload.action.type).toEqual(DELETE_UTXO);
-      expect(outpointToString(next.value.payload.action.payload)).toEqual('fakeTxid:8');
+      expect(next.value?.payload.action.type).toEqual(DELETE_UTXO);
+      expect(outpointToString(next.value?.payload.action.payload)).toEqual('fakeTxid:8');
     });
 
     test('should reset utxos if no utxos are discovered', async () => {
@@ -59,7 +59,7 @@ describe('wallet saga', () => {
       current[outpointToString(utxo)] = utxo;
       const gen = fetchAndUpdateUtxos([], current, APIURL);
 
-      const callEffect = gen.next().value as CallEffect<IteratorResult<UtxoInterface, number>>;
+      const callEffect = gen.next().value as StrictEffect<IteratorResult<UtxoInterface, number>>;
       const result = await callEffect.payload.fn();
       const put = gen.next(result).value as PutEffect<ActionType>;
 


### PR DESCRIPTION
- Restore providers, pegins, assets, txs, utxos before signing in (pin modal).
- Restoring providers triggers market fetching, so we gain a bit of time while the user is entering his pin
- Retry market fetching if request fail (3 times, 2 seconds delay)
- Monitor market fetching with new state variable `isFetchingMarkets`
  - if true, main screen top-right spinner is active
- Fix bug in `updateAssets` where we fetch same asset data multiple times 
- Show alert box if no providers available (no market or no best trade selected)

It closes #457 

Please review @tiero @louisinger 