### PR TITLE
[Fix] Use proper iOS status bar style

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,10 +52,10 @@ const App: React.FC<AppProps> = ({ appInit, isAuth, theme }) => {
       } catch (err) {
         console.error(err);
       }
-      try{
+      try {
         if (Capacitor.isPluginAvailable('StatusBar')) {
           await StatusBar.setStyle({
-            style: Style.Dark
+            style: Style.Dark,
           });
         }
       } catch (err) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useAppState } from '@capacitor-community/react-hooks/app';
 import { Capacitor } from '@capacitor/core';
-import { StatusBar } from '@capacitor/status-bar';
+import { StatusBar, Style } from '@capacitor/status-bar';
 import { IonApp, IonRouterOutlet } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import React, { useEffect } from 'react';
@@ -48,6 +48,15 @@ const App: React.FC<AppProps> = ({ appInit, isAuth, theme }) => {
       try {
         if (Capacitor.isPluginAvailable('StatusBar')) {
           await StatusBar.setOverlaysWebView({ overlay: false });
+        }
+      } catch (err) {
+        console.error(err);
+      }
+      try{
+        if (Capacitor.isPluginAvailable('StatusBar')) {
+          await StatusBar.setStyle({
+            style: Style.Dark
+          });
         }
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
Hello guys, love the project.

Maybe this was a deliberate design choice but using dark text on dark background makes the app looks kinda 'inconsistent' with other iOS apps (it feels a little bit non-native). [1] [2]

- [1] https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/dark-mode/

- [2] https://developer.apple.com/design/human-interface-guidelines/ios/bars/status-bars/

I added the recommended status bar style for dark backgrounds ( to be consistent with the native iOS experience )

<img width="366" alt="Screen Shot 2022-01-10 at 12 26 56 AM" src="https://user-images.githubusercontent.com/45250003/148747613-6c760ffb-c8b4-4ab1-b979-b069c7fead53.png"> 

<img width="363" alt="Screen Shot 2022-01-10 at 1 38 10 AM" src="https://user-images.githubusercontent.com/45250003/148748009-75da3510-2c5a-49d3-b916-33fa4e77ab15.png">
