### PR TITLE
Remove asset already added check

### DIFF
--- a/src/redux/sagas/transactionsSaga.ts
+++ b/src/redux/sagas/transactionsSaga.ts
@@ -100,15 +100,11 @@ export function* fetchAndUpdateTxs(
   }
 }
 
-// To avoid fetching same asset data multiple times
-const assetsSoonAddedInState: string[] = [];
-
 // update the assets state when a new transaction is set in tx state
 function* updateAssets({ payload }: ReturnType<typeof setTransaction>) {
   if (payload?.vout) {
     for (const out of payload.vout) {
-      if (!isBlindedOutputInterface(out) && !assetsSoonAddedInState.includes(out.asset)) {
-        assetsSoonAddedInState.push(out.asset);
+      if (!isBlindedOutputInterface(out)) {
         yield put(addAsset(out.asset));
       }
     }


### PR DESCRIPTION
When persistent storage is empty, all assets encountered in wallet transactions are added in store. 
A check was in place to ensure we don't ask the same asset data multiple times, but that check doesn't work if network is switched from settings because `assetsSoonAddedInState` is not reset.
Redux state can't be use here because it is not updated fast enough.

In this PR choice is made to simply remove the check, which results in making a few useless requests if storage/store is not already set. If txs are already in storage/store adding txs/assets is skipped so we don't make requests.

Please review @tiero 