### PR TITLE
Support any base asset

### DIFF
--- a/src/components/ExchangeRow/index.tsx
+++ b/src/components/ExchangeRow/index.tsx
@@ -16,7 +16,6 @@ import { fromSatoshi, fromSatoshiFixed, isLbtc, isLbtcTicker, toLBTCwithUnit, to
 import { sanitizeInputAmount } from '../../utils/input';
 import { onPressEnterKeyCloseKeyboard, setAccessoryBar } from '../../utils/keyboard';
 import { bestBalance, bestPrice, calculatePrice } from '../../utils/tdex';
-import type { AssetWithTicker } from '../../utils/tdex';
 import { CurrencyIcon } from '../icons';
 import './style.scss';
 
@@ -25,7 +24,7 @@ const ERROR_BALANCE_TOO_LOW = 'Amount is greater than your balance';
 interface ExchangeRowInterface {
   sendInput: boolean;
   // the asset handled by the component.
-  asset: AssetWithTicker;
+  asset: AssetConfig;
   assetAmount?: string;
   // using to auto-update with best trade price
   trades: TDEXTrade[];
@@ -36,8 +35,8 @@ interface ExchangeRowInterface {
   setTrade: (trade: TDEXTrade) => void;
   trade?: TDEXTrade;
   // for exchange search
-  assetsWithTicker: AssetWithTicker[];
-  setAsset: (newAsset: AssetWithTicker) => void;
+  assetsWithTicker: AssetConfig[];
+  setAsset: (newAsset: AssetConfig) => void;
   setFocus: () => void;
   focused: boolean;
   // redux connected props
@@ -99,7 +98,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
   });
 
   useEffect(() => {
-    setBalance(balances.find((b) => b.asset === asset.asset));
+    setBalance(balances.find((b) => b.assetHash === asset.assetHash));
   }, [balances, asset]);
 
   useEffect(() => {
@@ -161,13 +160,13 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
           if (!priceInSats) return;
           setTrade(newTrade);
           //
-          if (isLbtc(asset.asset, network)) {
+          if (isLbtc(asset.assetHash, network)) {
             const precision = assets[priceInSats.asset]?.precision ?? defaultPrecision;
             updatedAmount = fromSatoshiFixed(
               priceInSats.amount.toString(),
               precision,
               precision,
-              isLbtc(asset.asset, network) ? lbtcUnit : undefined
+              isLbtc(asset.assetHash, network) ? lbtcUnit : undefined
             );
           } else {
             // Convert fiat
@@ -191,7 +190,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
         setIsUpdating(false);
       }, 500),
     [
-      asset.asset,
+      asset.assetHash,
       assets,
       lbtcUnit,
       network,
@@ -248,7 +247,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
       const sanitizedValue = sanitizeInputAmount(
         e.detail.value,
         setAmount,
-        isLbtc(asset.asset, network) ? lbtcUnit : undefined
+        isLbtc(asset.assetHash, network) ? lbtcUnit : undefined
       );
       // Set
       setAmount(sanitizedValue);
@@ -257,7 +256,7 @@ const ExchangeRow: React.FC<ExchangeRowInterface> = ({
       const valSats = toSatoshi(
         sanitizedValue,
         balance?.precision,
-        isLbtc(asset.asset, network) ? lbtcUnit : undefined
+        isLbtc(asset.assetHash, network) ? lbtcUnit : undefined
       );
       if (sendInput && valSats.greaterThan(balance?.amount ?? 0)) {
         setError(ERROR_BALANCE_TOO_LOW);

--- a/src/components/ExchangeSearch/index.tsx
+++ b/src/components/ExchangeSearch/index.tsx
@@ -2,13 +2,13 @@ import { IonContent, IonList, IonModal, IonHeader, IonItem, IonInput, IonIcon } 
 import { closeSharp, searchSharp } from 'ionicons/icons';
 import React, { useState } from 'react';
 
-import type { AssetWithTicker } from '../../utils/tdex';
+import type { AssetConfig } from '../../utils/constants';
 import { CurrencyIcon } from '../icons';
 
 interface ExchangeSearchProps {
   prices: Record<string, number>;
-  assets: AssetWithTicker[];
-  setAsset: (newAsset: AssetWithTicker) => void;
+  assets: AssetConfig[];
+  setAsset: (newAsset: AssetConfig) => void;
   isOpen: boolean;
   close: (ev: any) => void;
   currency: string;
@@ -38,12 +38,12 @@ const ExchangeSearch: React.FC<ExchangeSearchProps> = ({ prices, assets, setAsse
         <IonList>
           {assets
             .filter(
-              (asset: AssetWithTicker) =>
-                asset.asset.toLowerCase().includes(searchString) ||
+              (asset: AssetConfig) =>
+                asset.assetHash.toLowerCase().includes(searchString) ||
                 asset.ticker.toLowerCase().includes(searchString) ||
                 asset.coinGeckoID?.toLowerCase().includes(searchString)
             )
-            .map((asset: AssetWithTicker, index: number) => {
+            .map((asset: AssetConfig, index: number) => {
               return (
                 <IonItem
                   className="ion-no-margin"

--- a/src/components/WithdrawRow/index.tsx
+++ b/src/components/WithdrawRow/index.tsx
@@ -44,12 +44,12 @@ const WithdrawRow: React.FC<WithdrawRowInterface> = ({ amount, balance, price, s
         balance.amount.toString(),
         balance.precision,
         balance.precision,
-        isLbtc(balance.asset, network) ? lbtcUnit : undefined
+        isLbtc(balance.assetHash, network) ? lbtcUnit : undefined
       )
     );
     if (price) setFiat('0.00');
     setAmount('');
-  }, [balance.amount, balance.asset, balance.precision, lbtcUnit, network, price, setAmount]);
+  }, [balance.amount, balance.assetHash, balance.precision, lbtcUnit, network, price, setAmount]);
 
   useEffect(() => {
     setAccessoryBar(true).catch(console.error);
@@ -67,17 +67,17 @@ const WithdrawRow: React.FC<WithdrawRowInterface> = ({ amount, balance, price, s
         balance.amount.toString(),
         balance.precision,
         balance.precision,
-        isLbtc(balance.asset, network) ? lbtcUnit : undefined
+        isLbtc(balance.assetHash, network) ? lbtcUnit : undefined
       )
     );
-  }, [lbtcUnit, balance.amount, balance.precision, balance.asset, network]);
+  }, [lbtcUnit, balance.amount, balance.precision, balance.assetHash, network]);
 
   const handleInputChange = (e: CustomEvent<InputChangeEventDetail>) => {
     if (!e.detail.value || e.detail.value === '0') {
       reset();
       return;
     }
-    const unit = isLbtc(balance.asset, network) ? lbtcUnit : undefined;
+    const unit = isLbtc(balance.assetHash, network) ? lbtcUnit : undefined;
     const sanitizedValue = sanitizeInputAmount(e.detail.value, setAmount, unit);
     // Set values
     setAmount(sanitizedValue);

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -33,20 +33,20 @@ import { addErrorToast, addSuccessToast } from '../../redux/actions/toastActions
 import { watchTransaction } from '../../redux/actions/transactionsActions';
 import { unlockUtxos } from '../../redux/actions/walletActions';
 import ExchangeRow from '../../redux/containers/exchangeRowContainer';
+import { getAssetData } from '../../redux/sagas/assetsSaga';
 import type { AssetConfig, LbtcDenomination } from '../../utils/constants';
 import { defaultPrecision, LBTC_ASSET, PIN_TIMEOUT_FAILURE, PIN_TIMEOUT_SUCCESS } from '../../utils/constants';
 import { AppError, IncorrectPINError } from '../../utils/errors';
 import { customCoinSelector, isLbtc, isLbtcTicker, toSatoshi } from '../../utils/helpers';
 import type { TDexMnemonicRedux } from '../../utils/identity';
 import { getConnectedTDexMnemonic } from '../../utils/storage-helper';
-import type { AssetWithTicker } from '../../utils/tdex';
 import { allTrades, makeTrade, getTradablesAssets } from '../../utils/tdex';
 import type { PreviewData } from '../TradeSummary';
 
 const ERROR_LIQUIDITY = 'Not enough liquidity in market';
 
 interface ExchangeProps extends RouteComponentProps {
-  allAssets: AssetWithTicker[];
+  allAssets: AssetConfig[];
   assets: Record<string, AssetConfig>;
   balances: BalanceInterface[];
   dispatch: Dispatch;
@@ -79,11 +79,11 @@ const Exchange: React.FC<ExchangeProps> = ({
   const [sentAmount, setSentAmount] = useState<string>();
   const [receivedAmount, setReceivedAmount] = useState<string>();
   // assets selected for trade
-  const [assetSent, setAssetSent] = useState<AssetWithTicker>();
-  const [assetReceived, setAssetReceived] = useState<AssetWithTicker>();
+  const [assetSent, setAssetSent] = useState<AssetConfig>();
+  const [assetReceived, setAssetReceived] = useState<AssetConfig>();
   // current trades/tradable assets
-  const [tradableAssetsForAssetSent, setTradableAssetsForAssetSent] = useState<AssetWithTicker[]>([]);
-  const [tradableAssetsForAssetReceived, setTradableAssetsForAssetReceived] = useState<AssetWithTicker[]>([]);
+  const [tradableAssetsForAssetSent, setTradableAssetsForAssetSent] = useState<AssetConfig[]>([]);
+  const [tradableAssetsForAssetReceived, setTradableAssetsForAssetReceived] = useState<AssetConfig[]>([]);
   const [trades, setTrades] = useState<TDEXTrade[]>([]);
   // selected trade
   const [bestTrade, setBestTrade] = useState<TDEXTrade>();
@@ -104,8 +104,8 @@ const Exchange: React.FC<ExchangeProps> = ({
       openNoProvidersAvailableAlert();
     }
     setAssetSent({
-      asset: LBTC_ASSET[network].assetHash,
-      ticker: LBTC_ASSET[network].ticker,
+      assetHash: assets[LBTC_ASSET[network].assetHash].assetHash ?? assets[0].assetHash,
+      ticker: assets[LBTC_ASSET[network].assetHash].ticker ?? assets[0].ticker,
     });
     setSentAmount(undefined);
     setReceivedAmount(undefined);
@@ -144,24 +144,34 @@ const Exchange: React.FC<ExchangeProps> = ({
 
   useEffect(() => {
     if (markets.length === 0 || !assetSent || !assetReceived) return;
-    setTrades(allTrades(markets, assetSent.asset, assetReceived.asset));
-  }, [assetSent?.asset, assetReceived?.asset, markets, assetSent, assetReceived]);
+    setTrades(allTrades(markets, assetSent.assetHash, assetReceived.assetHash));
+  }, [assetSent?.assetHash, assetReceived?.assetHash, markets, assetSent, assetReceived]);
 
   useEffect(() => {
-    if (!assetSent) return;
-    const sentTradables = getTradablesAssets(markets, assetSent.asset, network);
-    // TODO: Add opposite asset and remove current
-    setTradableAssetsForAssetReceived(sentTradables);
-    setAssetReceived(sentTradables[0]);
-  }, [assetSent, assetSent?.asset, markets, network]);
-
-  useEffect(() => {
-    if (assetReceived) {
-      const receivedTradables = getTradablesAssets(markets, assetReceived.asset, network);
+    void (async (): Promise<void> => {
+      if (!assetSent) return;
+      const sentTradables = getTradablesAssets(markets, assetSent.assetHash);
+      const assetsData = (
+        await Promise.all(sentTradables.map((asset) => getAssetData(asset, explorerLiquidAPI, network)))
+      ).filter(Boolean) as AssetConfig[];
       // TODO: Add opposite asset and remove current
-      setTradableAssetsForAssetSent(receivedTradables);
-    }
-  }, [assetReceived, assetReceived?.asset, markets, network]);
+      setTradableAssetsForAssetReceived(assetsData);
+      setAssetReceived(assetsData[0]);
+    })();
+  }, [assetSent, assetSent?.assetHash, assets, explorerLiquidAPI, markets, network]);
+
+  useEffect(() => {
+    void (async (): Promise<void> => {
+      if (assetReceived) {
+        const receivedTradables = getTradablesAssets(markets, assetReceived.assetHash);
+        const assetsData = (
+          await Promise.all(receivedTradables.map((asset) => getAssetData(asset, explorerLiquidAPI, network)))
+        ).filter(Boolean) as AssetConfig[];
+        // TODO: Add opposite asset and remove current
+        setTradableAssetsForAssetSent(assetsData);
+      }
+    })();
+  }, [assetReceived, assetReceived?.assetHash, assets, explorerLiquidAPI, markets, network]);
 
   const checkAvailableAmountSent = () => {
     if (!bestTrade || !sentAmount || !assetSent) return;
@@ -169,7 +179,7 @@ const Exchange: React.FC<ExchangeProps> = ({
       bestTrade.type === TradeType.BUY ? bestTrade.market.quoteAmount : bestTrade.market.baseAmount;
     const sats = toSatoshi(
       sentAmount,
-      assets[assetSent.asset]?.precision ?? defaultPrecision,
+      assets[assetSent.assetHash]?.precision ?? defaultPrecision,
       isLbtcTicker(assetSent.ticker) ? lbtcUnit : undefined
     );
     if (!hasBeenSwapped && availableAmount && sats.greaterThan(availableAmount)) {
@@ -185,7 +195,7 @@ const Exchange: React.FC<ExchangeProps> = ({
       bestTrade.type === TradeType.BUY ? bestTrade.market.baseAmount : bestTrade.market.quoteAmount;
     const sats = toSatoshi(
       receivedAmount,
-      assets[assetReceived.asset]?.precision ?? defaultPrecision,
+      assets[assetReceived.assetHash]?.precision ?? defaultPrecision,
       isLbtcTicker(assetReceived.ticker) ? lbtcUnit : undefined
     );
     if (!hasBeenSwapped && availableAmount && sats.greaterThan(availableAmount)) {
@@ -198,7 +208,7 @@ const Exchange: React.FC<ExchangeProps> = ({
   };
 
   const sentAmountGreaterThanBalance = () => {
-    const balance = balances.find((b) => b.asset === assetSent?.asset);
+    const balance = balances.find((b) => b.assetHash === assetSent?.assetHash);
     if (!balance || !sentAmount) return true;
     const amountAsSats = toSatoshi(sentAmount, balance.precision, isLbtcTicker(balance.ticker) ? lbtcUnit : undefined);
     return amountAsSats.greaterThan(balance.amount);
@@ -229,10 +239,10 @@ const Exchange: React.FC<ExchangeProps> = ({
         {
           amount: toSatoshi(
             sentAmount,
-            assets[assetSent.asset]?.precision ?? defaultPrecision,
-            isLbtc(assetSent.asset, network) ? lbtcUnit : undefined
+            assets[assetSent.assetHash]?.precision ?? defaultPrecision,
+            isLbtc(assetSent.assetHash, network) ? lbtcUnit : undefined
           ).toNumber(),
-          asset: assetSent.asset,
+          asset: assetSent.assetHash,
         },
         explorerLiquidAPI,
         utxos,
@@ -303,8 +313,10 @@ const Exchange: React.FC<ExchangeProps> = ({
             open={modalOpen}
             title="Unlock your seed"
             description={`Enter your secret PIN to send ${sentAmount} ${
-              isLbtc(assetSent.asset, network) ? lbtcUnit : assetSent.ticker
-            } and receive ${receivedAmount} ${isLbtc(assetReceived.asset, network) ? lbtcUnit : assetReceived.ticker}.`}
+              isLbtc(assetSent.assetHash, network) ? lbtcUnit : assetSent.ticker
+            } and receive ${receivedAmount} ${
+              isLbtc(assetReceived.assetHash, network) ? lbtcUnit : assetReceived.ticker
+            }.`}
             onConfirm={onPinConfirm}
             onClose={() => {
               setModalOpen(false);
@@ -337,7 +349,7 @@ const Exchange: React.FC<ExchangeProps> = ({
                 setFocus={() => setIsFocused('sent')}
                 setTrade={(t: TDEXTrade) => setBestTrade(t)}
                 relatedAssetAmount={receivedAmount || ''}
-                relatedAssetHash={assetReceived?.asset || ''}
+                relatedAssetHash={assetReceived?.assetHash || ''}
                 asset={assetSent}
                 assetAmount={sentAmount}
                 trades={trades}
@@ -348,7 +360,7 @@ const Exchange: React.FC<ExchangeProps> = ({
                 }}
                 assetsWithTicker={tradableAssetsForAssetSent}
                 setAsset={(asset) => {
-                  if (assetReceived && asset.asset === assetReceived.asset) setAssetReceived(assetSent);
+                  if (assetReceived && asset.assetHash === assetReceived.assetHash) setAssetReceived(assetSent);
                   setAssetSent(asset);
                 }}
                 error={errorSent}
@@ -373,7 +385,7 @@ const Exchange: React.FC<ExchangeProps> = ({
                   trades={trades}
                   trade={bestTrade}
                   relatedAssetAmount={sentAmount || ''}
-                  relatedAssetHash={assetSent?.asset || ''}
+                  relatedAssetHash={assetSent?.assetHash || ''}
                   asset={assetReceived}
                   assetAmount={receivedAmount}
                   onChangeAmount={(newAmount: string) => {
@@ -382,7 +394,7 @@ const Exchange: React.FC<ExchangeProps> = ({
                   }}
                   assetsWithTicker={tradableAssetsForAssetReceived}
                   setAsset={(asset) => {
-                    if (asset.asset === assetSent.asset) setAssetSent(assetReceived);
+                    if (asset.assetHash === assetSent.assetHash) setAssetSent(assetReceived);
                     setAssetReceived(asset);
                   }}
                   error={errorReceived}

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -100,12 +100,13 @@ const Exchange: React.FC<ExchangeProps> = ({
   const [showNoProvidersAvailableAlert, dismissNoProvidersAvailableAlert] = useIonAlert();
 
   useIonViewWillEnter(() => {
-    if (markets.length === 0) {
-      openNoProvidersAvailableAlert();
-    }
+    if (markets.length === 0) openNoProvidersAvailableAlert();
+    const lbtcInMarkets = markets.find(
+      (m) => m.baseAsset === LBTC_ASSET[network].assetHash || m.quoteAsset === LBTC_ASSET[network].assetHash
+    );
     setAssetSent({
-      assetHash: assets[LBTC_ASSET[network].assetHash].assetHash ?? assets[0].assetHash,
-      ticker: assets[LBTC_ASSET[network].assetHash].ticker ?? assets[0].ticker,
+      assetHash: lbtcInMarkets ? LBTC_ASSET[network].assetHash : assets[balances[0].assetHash].assetHash,
+      ticker: lbtcInMarkets ? LBTC_ASSET[network].ticker : assets[balances[0].assetHash].ticker,
     });
     setSentAmount(undefined);
     setReceivedAmount(undefined);

--- a/src/pages/Operations/index.tsx
+++ b/src/pages/Operations/index.tsx
@@ -75,13 +75,13 @@ const Operations: React.FC<OperationsProps> = ({
 
   // effect to select the balance
   useEffect(() => {
-    const balanceSelected = balances.find((bal) => bal.asset === asset_id);
+    const balanceSelected = balances.find((bal) => bal.assetHash === asset_id);
     if (balanceSelected) {
       setBalance(balanceSelected);
     } else {
       const asset = MAIN_ASSETS[network].find((a) => a.assetHash === asset_id);
       setBalance({
-        asset: asset?.assetHash ?? '',
+        assetHash: asset?.assetHash ?? '',
         amount: 0,
         coinGeckoID: asset?.coinGeckoID ?? '',
         ticker: asset?.ticker ?? '',
@@ -156,7 +156,7 @@ const Operations: React.FC<OperationsProps> = ({
                   pathname: '/receive',
                   state: {
                     depositAsset: {
-                      asset: balance?.asset,
+                      asset: balance?.assetHash,
                       ticker: balance?.ticker ?? LBTC_TICKER[network],
                       coinGeckoID: balance?.coinGeckoID ?? 'L-BTC',
                     },
@@ -191,7 +191,7 @@ const Operations: React.FC<OperationsProps> = ({
         </IonCol>
       </IonRow>
     ),
-    [asset_id, balance?.asset, balance?.coinGeckoID, balance?.ticker, history, network]
+    [asset_id, balance?.assetHash, balance?.coinGeckoID, balance?.ticker, history, network]
   );
 
   const AssetBalance = useMemo(

--- a/src/pages/Withdrawal/index.tsx
+++ b/src/pages/Withdrawal/index.tsx
@@ -91,7 +91,7 @@ const Withdrawal: React.FC<WithdrawalProps> = ({
 
   // Set current asset balance
   useEffect(() => {
-    const balanceSelected = balances.find((bal) => bal.asset === asset_id);
+    const balanceSelected = balances.find((bal) => bal.assetHash === asset_id);
     if (balanceSelected) {
       setBalance(balanceSelected);
     }
@@ -126,7 +126,7 @@ const Withdrawal: React.FC<WithdrawalProps> = ({
         fromSatoshi(
           balance.amount.toString(),
           balance.precision,
-          isLbtc(balance.asset, network) ? lbtcUnit : undefined
+          isLbtc(balance.assetHash, network) ? lbtcUnit : undefined
         ).lessThan(amount || '0')
       ) {
         setError('Amount is greater than your balance');
@@ -147,7 +147,7 @@ const Withdrawal: React.FC<WithdrawalProps> = ({
 
   const getRecipient = (): RecipientInterface => ({
     address: recipientAddress?.trim(),
-    asset: balance?.asset || '',
+    asset: balance?.assetHash || '',
     value: toSatoshi(
       amount || '0',
       balance?.precision,
@@ -276,7 +276,7 @@ const Withdrawal: React.FC<WithdrawalProps> = ({
                     if (options?.amount) {
                       // Treat the amount as in btc unit
                       // Convert to user favorite unit, taking into account asset precision
-                      const unit = isLbtc(balance?.asset || '', network) ? lbtcUnit : undefined;
+                      const unit = isLbtc(balance?.assetHash || '', network) ? lbtcUnit : undefined;
                       const amtConverted = fromLbtcToUnit(
                         new Decimal(options?.amount as string),
                         unit,

--- a/src/redux/actionTypes/walletActionTypes.ts
+++ b/src/redux/actionTypes/walletActionTypes.ts
@@ -1,8 +1,5 @@
-export interface BalanceInterface {
-  asset: string;
+import type { AssetConfig } from '../../utils/constants';
+
+export interface BalanceInterface extends AssetConfig {
   amount: number;
-  ticker: string;
-  name: string;
-  precision: number;
-  coinGeckoID?: string;
 }

--- a/src/redux/containers/circleDiagramContainer.tsx
+++ b/src/redux/containers/circleDiagramContainer.tsx
@@ -13,7 +13,7 @@ const mapStateToProps = (state: RootState): CircleDiagramProps => {
       .map((balance: BalanceInterface) => {
         const price: number | undefined = state.rates.lbtcPrices[balance.coinGeckoID || ''];
         return {
-          asset: balance.asset,
+          asset: balance.assetHash,
           ticker: balance.ticker,
           amount: (price || 1) * balance.amount,
         };

--- a/src/redux/containers/exchangeContainer.tsx
+++ b/src/redux/containers/exchangeContainer.tsx
@@ -9,7 +9,7 @@ const mapStateToProps = (state: RootState) => {
   return {
     assets: state.assets,
     balances: balancesSelector(state).filter(
-      (b) => b.amount > 0 && getTradablesAssets(state.tdex.markets, b.asset, state.settings.network).length > 0
+      (b) => b.amount > 0 && getTradablesAssets(state.tdex.markets, b.assetHash).length > 0
     ),
     explorerLiquidAPI: state.settings.explorerLiquidAPI,
     isFetchingMarkets: state.app.isFetchingMarkets,

--- a/src/redux/reducers/tdexReducer.ts
+++ b/src/redux/reducers/tdexReducer.ts
@@ -2,7 +2,6 @@ import type { NetworkString } from 'tdex-sdk';
 
 import type { AssetConfig } from '../../utils/constants';
 import { tickerFromAssetHash } from '../../utils/helpers';
-import type { AssetWithTicker } from '../../utils/tdex';
 import type { ActionType } from '../../utils/types';
 import type { TDEXMarket, TDEXProvider } from '../actionTypes/tdexActionTypes';
 import { ADD_MARKETS, ADD_PROVIDERS, CLEAR_MARKETS, CLEAR_PROVIDERS, DELETE_PROVIDER } from '../actions/tdexActions';
@@ -57,12 +56,12 @@ export const allAssets = ({
   assets: Record<string, AssetConfig>;
   tdex: TDEXState;
   network: NetworkString;
-}): AssetWithTicker[] => {
+}): AssetConfig[] => {
   const quoteAssets = tdex.markets.map((m) => m.quoteAsset);
   const baseAssets = tdex.markets.map((m) => m.baseAsset);
   const uniqueAssets = [...new Set([...quoteAssets, ...baseAssets])];
   return uniqueAssets.map((assetHash: string) => ({
-    asset: assetHash,
+    assetHash: assetHash,
     ticker: assets[assetHash]?.ticker || tickerFromAssetHash(network, assetHash),
     coinGeckoID: assets[assetHash]?.coinGeckoID,
   }));

--- a/src/redux/reducers/walletReducer.ts
+++ b/src/redux/reducers/walletReducer.ts
@@ -138,29 +138,29 @@ export const balancesSelector = createSelector(
   ],
   ({ assets, settings }, utxos, txsAssets) => {
     const balances = balancesFromUtxos(utxos, assets, settings.network);
-    const balancesAssets = balances.map((b) => b.asset);
+    const balancesAssets = balances.map((b) => b.assetHash);
     for (const asset of txsAssets) {
       if (balancesAssets.includes(asset)) continue;
       // include a 'zero' balance if the user has previous transactions.
       balances.push({
-        asset,
+        assetHash: asset,
         amount: 0,
         ticker: assets[asset]?.ticker ?? tickerFromAssetHash(settings.network, asset),
         coinGeckoID: getMainAsset(asset, settings.network)?.coinGeckoID,
         precision: assets[asset]?.precision ?? defaultPrecision,
-        name: assets[asset]?.name,
+        name: assets[asset]?.name ?? 'Unknown',
       });
     }
     // If no balance, add LBTC with amount zero
     const lbtcAsset = LBTC_ASSET[settings.network];
     if (!balances.length) {
       balances.push({
-        asset: lbtcAsset.assetHash,
+        assetHash: lbtcAsset.assetHash,
         amount: 0,
         ticker: lbtcAsset.ticker,
         coinGeckoID: lbtcAsset.coinGeckoID,
-        precision: lbtcAsset.precision,
-        name: lbtcAsset.name,
+        precision: lbtcAsset.precision ?? defaultPrecision,
+        name: lbtcAsset.name ?? 'Unknown',
       });
     }
     return balances;
@@ -185,7 +185,7 @@ export const aggregatedLBTCBalanceSelector = (state: RootState): BalanceInterfac
   const amount = toAggregateBalancesInBTC.reduce((acc, a) => acc + a, 0);
   return {
     amount,
-    asset: '',
+    assetHash: '',
     ticker: LBTC_ASSET[state.settings.network].ticker,
     coinGeckoID: LBTC_COINGECKOID,
     precision: 8,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -29,9 +29,9 @@ export interface AssetConfig {
   coinGeckoID?: string;
   ticker: string;
   assetHash: string;
-  color: string;
-  precision: number;
-  name: string;
+  color?: string;
+  precision?: number;
+  name?: string;
 }
 
 export const LBTC_ASSET: Record<NetworkString, AssetConfig> = {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -164,12 +164,12 @@ export function balancesFromUtxos(
     const amount = sumUtxos(utxosForAsset);
     const coinGeckoID = getMainAsset(asset, network)?.coinGeckoID;
     balances.push({
-      asset,
+      assetHash: asset,
       amount,
       ticker: assets[asset]?.ticker || tickerFromAssetHash(network, asset),
       coinGeckoID,
       precision: assets[asset]?.precision ?? defaultPrecision,
-      name: assets[asset]?.name,
+      name: assets[asset]?.name ?? 'Unknown',
     });
   }
 


### PR DESCRIPTION
It closes #444 

- Set asset data based on assets in transactions and in markets. 
- Default market is LBTC/xxx if Lbtc is one of the asset of a market, otherwise send asset is the first in asset list.
- Simplify code by removing AssetWithTicker interface, use AssetConfig instead (asset -> assetHash).

Please review @tiero 