### PR TITLE
Refactor generators

### DIFF
--- a/src/redux/sagas/transactionsSaga.ts
+++ b/src/redux/sagas/transactionsSaga.ts
@@ -90,15 +90,12 @@ export function* fetchAndUpdateTxs(
   );
   const next = () => txsGen.next();
   let it: IteratorResult<TxInterface, number> = yield call(next);
-  if (it.done) {
-    yield put(setIsFetchingTransactions(false));
-    return;
-  }
   while (!it.done) {
     const tx = it.value;
     yield put(setTransaction(tx));
     it = yield call(next);
   }
+  yield put(setIsFetchingTransactions(false));
 }
 
 // update the assets state when a new transaction is set in tx state

--- a/src/redux/sagas/walletSaga.ts
+++ b/src/redux/sagas/walletSaga.ts
@@ -14,7 +14,6 @@ import { addErrorToast } from '../actions/toastActions';
 import type { watchUtxo } from '../actions/walletActions';
 import {
   deleteUtxo,
-  resetUtxos,
   setUtxo,
   unlockUtxo,
   ADD_ADDRESS,
@@ -81,12 +80,6 @@ export function* fetchAndUpdateUtxos(
   );
   const next = () => utxoGen.next();
   let it = yield call(next);
-  // if done = true it means that we do not find any utxos
-  if (it.done) {
-    yield put(resetUtxos());
-    yield put(setIsFetchingUtxos(false));
-    return;
-  }
   let utxoUpdatedCount = 0;
   while (!it.done) {
     const utxo = it.value;

--- a/test/saga/wallet.saga.spec.ts
+++ b/test/saga/wallet.saga.spec.ts
@@ -4,7 +4,7 @@ import type { AddressInterface, UtxoInterface } from 'ldk';
 import { fetchAndUnblindUtxos } from 'ldk';
 import type { PutEffect, StrictEffect } from 'redux-saga/effects';
 
-import { SET_UTXO, DELETE_UTXO, RESET_UTXOS } from '../../src/redux/actions/walletActions';
+import { SET_UTXO, DELETE_UTXO } from '../../src/redux/actions/walletActions';
 import { outpointToString } from '../../src/redux/reducers/walletReducer';
 import { fetchAndUpdateUtxos } from '../../src/redux/sagas/walletSaga';
 import type { ActionType } from '../../src/utils/types';
@@ -50,18 +50,6 @@ describe('wallet saga', () => {
       }
       expect(next.value?.payload.action.type).toEqual(DELETE_UTXO);
       expect(outpointToString(next.value?.payload.action.payload)).toEqual('fakeTxid:8');
-    });
-
-    test('should reset utxos if no utxos are discovered', async () => {
-      const current: Record<string, UtxoInterface> = {};
-      current[outpointToString(utxo)] = utxo;
-      const gen = fetchAndUpdateUtxos([], current, APIURL);
-      const setIsFetchingMarkets = gen.next().value as PutEffect<ActionType<boolean>>;
-      expect(setIsFetchingMarkets.payload.action.payload).toEqual(true);
-      const callEffect = gen.next().value as StrictEffect<IteratorResult<UtxoInterface, number>>;
-      const result = await callEffect.payload.fn();
-      const put = gen.next(result).value as PutEffect<ActionType>;
-      expect(put.payload.action.type).toEqual(RESET_UTXOS);
     });
   });
 });


### PR DESCRIPTION
while (!it.done) loop has to be executed first. When we exit from loop it means it.done === true.

The only time `resetUtxos()` was executed is when it's a brand new wallet with no utxos. So it's useless to resetUtxos there.