### PR TITLE
Update markets once at init_app_success

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
   "baseUrl": "http://localhost:8100",
-  "viewportHeight": 568,
-  "viewportWidth": 320
+  "viewportHeight": 740,
+  "viewportWidth": 360
 }

--- a/cypress/integration/main.spec.ts
+++ b/cypress/integration/main.spec.ts
@@ -35,8 +35,7 @@ describe('trade', () => {
   it('make a trade', () => {
     cy.launchWallet();
     cy.get('[data-cy=tab-exchange]').click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000);
+    cy.url().should('contain', '/exchange');
     cy.get('[data-cy=exchange-send-input]').children().type('1');
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(2500);
@@ -45,6 +44,7 @@ describe('trade', () => {
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(1000);
     cy.get('[data-cy=pin-input]').children().type(pin);
+    cy.url().should('contain', '/tradesummary/');
     cy.get('[data-cy=header-title]').should('contain.text', 'TRADE SUMMARY');
     cy.get('[data-cy=trade-summary-sent-amount]').should('contain.text', '-1');
   });
@@ -54,8 +54,7 @@ describe('trade', () => {
     cy.wait(6000);
     cy.launchWallet({ 'CapacitorStorage.tdex-app-lbtc-unit': 'L-sats' });
     cy.get('[data-cy=tab-exchange]').click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000);
+    cy.url().should('contain', '/exchange');
     cy.get('[data-cy=exchange-send-input]').children().type('1000');
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(2500);

--- a/src/components/TdexOrderInput/hooks.ts
+++ b/src/components/TdexOrderInput/hooks.ts
@@ -12,11 +12,12 @@ import type { SatsAsset, AmountAndUnit } from '.';
 
 export function createAmountAndUnit(assetsRegistry: Record<string, AssetConfig>, lbtcUnit: LbtcDenomination) {
   return (satsAsset: SatsAsset): AmountAndUnit => {
-    if (!satsAsset.asset || !satsAsset.sats)
+    if (!satsAsset.asset || !satsAsset.sats || !assetsRegistry[satsAsset.asset]) {
       return {
         amount: '0',
         unit: 'unknown',
       };
+    }
     const assetConfig = assetsRegistry[satsAsset.asset];
     return {
       amount: fromSatoshiFixed(

--- a/src/components/TdexOrderInput/index.tsx
+++ b/src/components/TdexOrderInput/index.tsx
@@ -8,8 +8,6 @@ import swap from '../../assets/img/swap.svg';
 import TradeRowInput from '../../components/TdexOrderInput/TradeRowInput';
 import type { TDEXMarket } from '../../redux/actionTypes/tdexActionTypes';
 import type { BalanceInterface } from '../../redux/actionTypes/walletActionTypes';
-import { updateMarkets } from '../../redux/actions/tdexActions';
-import { useTypedDispatch } from '../../redux/hooks';
 import { balancesSelector } from '../../redux/reducers/walletReducer';
 import type { RootState } from '../../redux/types';
 import type { AssetConfig, LbtcDenomination } from '../../utils/constants';
@@ -96,8 +94,6 @@ const TdexOrderInput: React.FC<Props> = ({
   setSendAssetHasChanged,
   setReceiveAssetHasChanged,
 }) => {
-  const dispatch = useTypedDispatch();
-
   useIonViewDidEnter(() => {
     setAccessoryBar(true).catch(console.error);
     // Set send asset default to LBTC if available in markets, or first asset in balances

--- a/src/components/TdexOrderInput/index.tsx
+++ b/src/components/TdexOrderInput/index.tsx
@@ -120,11 +120,6 @@ const TdexOrderInput: React.FC<Props> = ({
   }, []);
 
   useEffect(() => {
-    dispatch(updateMarkets());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
     if (sendError || receiveError) onInput(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sendError, receiveError]);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,3 +31,8 @@ ReactDOM.render(
   </Provider>,
   document.getElementById('root')
 );
+
+// expose store when run in Cypress
+if ('Cypress' in window) {
+  (window as any).store = store;
+}

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -128,7 +128,9 @@ const Exchange: React.FC<Props> = ({
     providers.filter((p) => !excludedProviders.map((p) => p.endpoint).includes(p.endpoint));
 
   useIonViewWillEnter(() => {
-    if (providers.length === 0) {
+    // Prevent entering Exchange page if no provider or no markets
+    // We may have the default provider set but no markets, so we need to check both
+    if (providers.length === 0 || markets.length === 0) {
       openNoProvidersAvailableAlert();
     }
   }, [providers]);
@@ -281,6 +283,7 @@ const Exchange: React.FC<Props> = ({
         onClose={() => setTradeError(undefined)}
         onClickRetry={() => tdexOrderInputResult !== undefined && setPINModalOpen(true)}
         onClickTryNext={(providerToBan: TDEXProvider) => {
+          console.log('onClickTryNext');
           if (getAllProvidersExceptExcluded().length > 1) {
             if (!excludedProviders.map((p) => p.endpoint).includes(providerToBan.endpoint)) {
               setExcludedProviders([...excludedProviders, providerToBan]);

--- a/src/pages/Exchange/index.tsx
+++ b/src/pages/Exchange/index.tsx
@@ -260,6 +260,34 @@ const Exchange: React.FC<Props> = ({
     }
   };
 
+  const onClickTryNext = (providerToBan: TDEXProvider) => {
+    if (getAllProvidersExceptExcluded().length > 1) {
+      if (!excludedProviders.map((p) => p.endpoint).includes(providerToBan.endpoint)) {
+        setExcludedProviders([...excludedProviders, providerToBan]);
+        setTdexOrderInputResult(undefined);
+      }
+      if (getAllMarketsFromNotExcludedProvidersAndOnlySelectedPair(providerToBan).length === 0) {
+        dispatch(addErrorToast(NoMarketsAvailableForSelectedPairError));
+        // Set next possible trading pair
+        setSendLoader(false);
+        setReceiveLoader(false);
+        setSendAmount(0).catch(console.error);
+        setReceiveAmount(0).catch(console.error);
+        const tradableAssets = getTradablesAssets(markets, sendAsset || '').filter((t) => t !== receiveAsset);
+        if (tradableAssets.length > 0) {
+          setSendAsset(sendAsset);
+          setReceiveAsset(tradableAssets[0]);
+        } else {
+          const tradableAssets = getTradablesAssets(markets, receiveAsset || '').filter((t) => t !== sendAsset);
+          setSendAsset(receiveAsset);
+          setReceiveAsset(tradableAssets[0]);
+        }
+      }
+    } else {
+      dispatch(addErrorToast(NoOtherProvider));
+    }
+  };
+
   return (
     <IonPage id="exchange-page">
       <Loader showLoading={isBusyMakingTrade} delay={0} />
@@ -282,34 +310,7 @@ const Exchange: React.FC<Props> = ({
         error={tradeError}
         onClose={() => setTradeError(undefined)}
         onClickRetry={() => tdexOrderInputResult !== undefined && setPINModalOpen(true)}
-        onClickTryNext={(providerToBan: TDEXProvider) => {
-          console.log('onClickTryNext');
-          if (getAllProvidersExceptExcluded().length > 1) {
-            if (!excludedProviders.map((p) => p.endpoint).includes(providerToBan.endpoint)) {
-              setExcludedProviders([...excludedProviders, providerToBan]);
-              setTdexOrderInputResult(undefined);
-            }
-            if (getAllMarketsFromNotExcludedProvidersAndOnlySelectedPair(providerToBan).length === 0) {
-              dispatch(addErrorToast(NoMarketsAvailableForSelectedPairError));
-              // Set next possible trading pair
-              setSendLoader(false);
-              setReceiveLoader(false);
-              setSendAmount(0).catch(console.error);
-              setReceiveAmount(0).catch(console.error);
-              const tradableAssets = getTradablesAssets(markets, sendAsset || '').filter((t) => t !== receiveAsset);
-              if (tradableAssets.length > 0) {
-                setSendAsset(sendAsset);
-                setReceiveAsset(tradableAssets[0]);
-              } else {
-                const tradableAssets = getTradablesAssets(markets, receiveAsset || '').filter((t) => t !== sendAsset);
-                setSendAsset(receiveAsset);
-                setReceiveAsset(tradableAssets[0]);
-              }
-            }
-          } else {
-            dispatch(addErrorToast(NoOtherProvider));
-          }
-        }}
+        onClickTryNext={onClickTryNext}
       />
 
       {getAllMarketsFromNotExcludedProviders().length > 0 && (

--- a/src/redux/sagas/appSaga.ts
+++ b/src/redux/sagas/appSaga.ts
@@ -79,7 +79,6 @@ function* signInSaga({ payload: identity }: ReturnType<typeof signIn>) {
       put(watchCurrentBtcBlockHeight()),
       put(updateDepositPeginUtxos()),
       put(checkIfClaimablePeginUtxo()),
-      put(updateMarkets()),
       put(updateTransactions()),
       put(updatePrices()),
       put(updateUtxos()),

--- a/src/redux/sagas/tdexSaga.ts
+++ b/src/redux/sagas/tdexSaga.ts
@@ -15,6 +15,7 @@ import {
   CLEAR_PROVIDERS,
   DELETE_PROVIDER,
   UPDATE_MARKETS,
+  updateMarkets,
 } from '../actions/tdexActions';
 import { addErrorToast } from '../actions/toastActions';
 import type { RootState, SagaGenerator, Unwrap } from '../types';
@@ -138,8 +139,8 @@ function* updateAssetsFromMarkets() {
 
 export function* tdexWatcherSaga(): SagaGenerator {
   yield takeLatest(ADD_PROVIDERS, function* () {
-    yield* fetchMarketsAndAddToState();
     yield* persistProviders();
+    yield put(updateMarkets());
   });
   yield takeLatest([CLEAR_PROVIDERS, DELETE_PROVIDER], persistProviders);
   yield takeLatest(UPDATE_MARKETS, function* () {


### PR DESCRIPTION
Currently markets are fetched at least 3 times:
1) At INIT_APP_SUCCESS, restoreProviders triggers markets fetching
2) At sign-in we update markets again
3) update again when entering Exchange page

Pulling down to refresh is also triggering updateMarkets if for some reason it is not up to date  

These requests are unnecessary, this PR only keeps market fetching at INIT_APP_SUCCESS (before sign-in).  

When doing a trade, if strategy is bestPrice, `MarketPrice` requests for all markets will be done, if strategy is bestBalance, `Balances` requests for all markets will be done.
