### PR TITLE
Cleanup exchange 

### DIFF
--- a/src/components/TdexOrderInput/index.tsx
+++ b/src/components/TdexOrderInput/index.tsx
@@ -103,7 +103,7 @@ const TdexOrderInput: React.FC<Props> = ({
     // Set receive asset to first tradable asset
     const tradableAssets = getTradablesAssets(markets, sendAsset);
     setReceiveAsset(tradableAssets[0]);
-  });
+  }, [markets, sendAsset]);
 
   useIonViewDidLeave(() => {
     setAccessoryBar(false).catch(console.error);

--- a/src/redux/actions/tdexActions.ts
+++ b/src/redux/actions/tdexActions.ts
@@ -7,9 +7,18 @@ export const CLEAR_PROVIDERS = 'CLEAR_PROVIDERS';
 export const UPDATE_MARKETS = 'UPDATE_MARKETS';
 export const ADD_MARKETS = 'ADD_MARKETS';
 export const CLEAR_MARKETS = 'CLEAR_MARKETS';
+export const REPLACE_MARKETS_OF_PROVIDER = 'REPLACE_MARKETS_OF_PROVIDER';
 
 export const clearMarkets = (): ActionType => ({
   type: CLEAR_MARKETS,
+});
+
+export const replaceMarketsOfProvider = (
+  providerToUpdate: TDEXProvider,
+  markets: TDEXMarket[]
+): ActionType<{ providerToUpdate: TDEXProvider; markets: TDEXMarket[] }> => ({
+  type: REPLACE_MARKETS_OF_PROVIDER,
+  payload: { providerToUpdate, markets },
 });
 
 export const addMarkets = (markets: TDEXMarket[]): ActionType<TDEXMarket[]> => {

--- a/src/redux/reducers/tdexReducer.ts
+++ b/src/redux/reducers/tdexReducer.ts
@@ -2,7 +2,14 @@ import { createSelector } from 'reselect';
 
 import type { ActionType } from '../../utils/types';
 import type { TDEXMarket, TDEXProvider } from '../actionTypes/tdexActionTypes';
-import { ADD_MARKETS, ADD_PROVIDERS, CLEAR_MARKETS, CLEAR_PROVIDERS, DELETE_PROVIDER } from '../actions/tdexActions';
+import {
+  ADD_MARKETS,
+  ADD_PROVIDERS,
+  CLEAR_MARKETS,
+  REPLACE_MARKETS_OF_PROVIDER,
+  CLEAR_PROVIDERS,
+  DELETE_PROVIDER,
+} from '../actions/tdexActions';
 import type { RootState } from '../types';
 
 export interface TDEXState {
@@ -22,6 +29,13 @@ const TDEXReducer = (
   switch (action.type) {
     case ADD_MARKETS:
       return { ...state, markets: [...state.markets, ...action.payload] };
+    case REPLACE_MARKETS_OF_PROVIDER: {
+      // Remove markets of provider received in arg
+      const marketsWithoutProviderToUpdate = state.markets.filter(
+        (market) => market.provider.endpoint !== (action.payload.providerToUpdate as TDEXProvider).endpoint
+      );
+      return { ...state, markets: [...marketsWithoutProviderToUpdate, ...action.payload.markets] };
+    }
     case CLEAR_MARKETS:
       return { ...state, markets: [] };
     case ADD_PROVIDERS: {

--- a/src/utils/tdex.ts
+++ b/src/utils/tdex.ts
@@ -25,7 +25,7 @@ export function createTraderClient(endpoint: string, proxy = 'https://proxy.tdex
 export function createDiscoverer(
   orders: TradeOrder[],
   discovery: Discovery,
-  errorHandler?: () => Promise<void>
+  errorHandler?: (err: any) => Promise<void>
 ): Discoverer {
   return new Discoverer(orders, discovery, errorHandler);
 }
@@ -150,12 +150,14 @@ export function discoverBestOrder(
   }
   return async (sats: number, asset: string): Promise<TradeOrder> => {
     if (sats <= 0) {
+      // return a random order to avoid calling discoverer
       return allPossibleOrders[0];
     }
     try {
       const discoverer = tdex.createDiscoverer(
         allPossibleOrders,
-        combineDiscovery(bestPriceDiscovery, bestBalanceDiscovery)
+        combineDiscovery(bestPriceDiscovery, bestBalanceDiscovery),
+        async (err) => console.error(err)
       );
       const bestOrders = await discoverer.discover({ asset, amount: sats });
       if (bestOrders.length === 0) throw new Error('zero best orders found by discoverer');

--- a/src/utils/tdex.ts
+++ b/src/utils/tdex.ts
@@ -157,7 +157,7 @@ export function discoverBestOrder(
       const discoverer = tdex.createDiscoverer(
         allPossibleOrders,
         combineDiscovery(bestPriceDiscovery, bestBalanceDiscovery),
-        async (err) => console.error(err)
+        async (err) => console.debug(err)
       );
       const bestOrders = await discoverer.discover({ asset, amount: sats });
       if (bestOrders.length === 0) throw new Error('zero best orders found by discoverer');


### PR DESCRIPTION
- Simplify updateReceiveSats and updateSendSats in src/components/TdexOrderInput/hooks.ts
- Use IonAlert as a component to have simpler code and fix edge cases
- Hide "Market provided by: ..." if sendSats is zero
- New action replaceMarketsOfProvider instead of addMarkets to update properly when provider/markets goes down. Also simpler code
- Log createDiscoverer errors
- Fix getMarketsFromProvider retry (not catching in fn)

Please review @tiero 