### PR TITLE
Delay setup screen until loading is done

### DIFF
--- a/android/app/src/main/assets/capacitor.config.json
+++ b/android/app/src/main/assets/capacitor.config.json
@@ -3,9 +3,10 @@
 	"appName": "TDEX",
 	"bundledWebRuntime": false,
 	"webDir": "build",
+	"backgroundColor": "#000000",
 	"plugins": {
 		"SplashScreen": {
-			"launchShowDuration": 0
+			"launchShowDuration": 100
 		}
 	},
 	"cordova": {}

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -7,9 +7,10 @@ const config: CapacitorConfig = {
   appName: 'TDEX',
   bundledWebRuntime: false,
   webDir: 'build',
+  backgroundColor: "#000000",
   plugins: {
     SplashScreen: {
-      launchShowDuration: 0,
+      launchShowDuration: 100,
     },
   },
   cordova: {},

--- a/ios/App/App/capacitor.config.json
+++ b/ios/App/App/capacitor.config.json
@@ -3,9 +3,10 @@
 	"appName": "TDEX",
 	"bundledWebRuntime": false,
 	"webDir": "build",
+	"backgroundColor": "#000000",
 	"plugins": {
 		"SplashScreen": {
-			"launchShowDuration": 0
+			"launchShowDuration": 100
 		}
 	},
 	"cordova": {}

--- a/src/pages/Homescreen/index.tsx
+++ b/src/pages/Homescreen/index.tsx
@@ -64,7 +64,9 @@ const Homescreen: React.FC = () => {
     };
     init()
       .catch(console.error)
-      .finally(() => setLoading(false));
+      .finally(() => {
+        setTimeout(() => setLoading(false), 100);
+      });
   });
 
   return (
@@ -82,21 +84,25 @@ const Homescreen: React.FC = () => {
         setIsWrongPin={setIsWrongPin}
       />
       <IonContent>
-        <IonGrid className="ion-text-center ion-justify-content-evenly">
-          <IonRow className="img-container">
-            <IonCol size="8" offset="2" sizeMd="6" offsetMd="3">
-              <img src={logo} alt="tdex logo" />
-            </IonCol>
-          </IonRow>
+        {loading ? (
+          <></>
+        ) : (
+          <IonGrid className="ion-text-center ion-justify-content-evenly">
+            <IonRow className="img-container">
+              <IonCol size="8" offset="2" sizeMd="6" offsetMd="3">
+                <img src={logo} alt="tdex logo" />
+              </IonCol>
+            </IonRow>
 
-          <ButtonsMainSub
-            mainTitle="SETUP WALLET"
-            mainLink="/onboarding/backup"
-            subTitle="RESTORE WALLET"
-            subLink="/restore"
-            className="btn-container"
-          />
-        </IonGrid>
+            <ButtonsMainSub
+              mainTitle="SETUP WALLET"
+              mainLink="/onboarding/backup"
+              subTitle="RESTORE WALLET"
+              subLink="/restore"
+              className="btn-container"
+            />
+          </IonGrid>
+        )}
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
I have a small UX proposal for the app

Every time somebody opens the app you can see the initial "setup screen" for a slight second before the pin modal pops up

This PR makes sure that if the user already has "wallet" they won't see the initial setup screen every time they open the app

**Current Launch UX**
![old](https://user-images.githubusercontent.com/45250003/161417186-77f5c6f0-84ce-4392-9064-12b8f4b56f78.gif)

**Proposed Launch UX**
![new](https://user-images.githubusercontent.com/45250003/161417202-ab2e6842-02fa-46db-8d45-8a5fc541c178.gif)


