### PR TITLE
Add Wasm support to iOS Capacitor

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -35,6 +35,11 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+    <dict>
+    	<key>NSAllowsArbitraryLoads</key>
+    	<true/>
+    </dict>
 	<key>NSCameraUsageDescription</key>
 	<string>To be able to scan barcodes</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -35,11 +35,6 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>To be able to scan barcodes</string>
 	<key>NSMicrophoneUsageDescription</key>
@@ -69,5 +64,25 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>UTExportedTypeDeclarations</key>
+    <array>
+    	<dict>
+    		<key>UTTypeConformsTo</key>
+   			<array>
+   				<string>public.data</string>
+   			</array>
+   			<key>UTTypeDescription</key>
+   			<string>WebAssembly</string>
+   			<key>UTTypeIdentifier</key>
+   			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+   			<key>UTTypeTagSpecification</key>
+   			<dict>
+    			<key>public.filename-extension</key>
+    			<string>wasm</string>
+    			<key>public.mime-type</key>
+   				<string>application/wasm</string>
+   			</dict>
+   		</dict>
+   	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes WASM mimetype for static file server in a production-bundled iOS app

See: https://github.com/ionic-team/capacitor/pull/5585