### PR TITLE
close modal before navigating

### DIFF
--- a/src/pages/Account/index.tsx
+++ b/src/pages/Account/index.tsx
@@ -41,6 +41,7 @@ const Account: React.FC<RouteComponentProps> = ({ history }) => {
         setIsWrongPin(false);
         setPinNeedReset(true);
         setTimeout(() => {
+          setPinModalOpen(false);
           setIsWrongPin(null);
           if (routeToGo === '/settings/show-mnemonic') {
             history.replace({


### PR DESCRIPTION
Closing modal was not necessary in Ionic 5 but is in Ionic 6