### PR TITLE
Close modal after send

### DIFF
--- a/src/pages/Withdrawal/index.tsx
+++ b/src/pages/Withdrawal/index.tsx
@@ -228,6 +228,9 @@ const Withdrawal: React.FC<WithdrawalProps> = ({
       }, PIN_TIMEOUT_FAILURE);
       dispatch(unlockUtxos());
       dispatch(addErrorToast(WithdrawTxError));
+    } finally {
+      setModalOpen(false);
+      setLoading(false);
     }
   };
 


### PR DESCRIPTION
It closes #572 

A change in React now requires to close the modal even if `history.replace` is called 